### PR TITLE
Fix release workflow for branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,6 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version_bump:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
       release_notes:
         description: 'What changed in the API spec'
         required: true
@@ -29,19 +21,15 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npx tsc
-      - name: Bump version
+      - name: Get version
         id: version
-        run: |
-          npm version ${{ github.event.inputs.version_bump }} --no-git-tag-version
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
-      - name: Commit and tag
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+      - name: Create tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
-          git commit -m "Release v${{ steps.version.outputs.version }}"
           git tag "v${{ steps.version.outputs.version }}"
-          git push origin main --tags
+          git push origin "v${{ steps.version.outputs.version }}"
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- Rewrote the release workflow to stop bumping the version and pushing commits directly to main, which is blocked by org-level branch protection rules.
- The workflow now reads the current version from `package.json` and only pushes a lightweight git tag.
- Version bumps are expected to happen in PRs going forward, keeping main protected.

## Test plan
- [ ] Verify the workflow file is valid YAML and appears correctly in the Actions tab.
- [ ] Run the workflow manually via `workflow_dispatch` and confirm it reads the version from `package.json`, creates the correct tag, and publishes a GitHub release.
- [ ] Confirm no commits are pushed to main by the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)