### PR TITLE
Update OpenAPI spec and bump to v1.1.0

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -29,6 +29,7 @@ docs/Competency.md
 docs/Conflict.md
 docs/Contract.md
 docs/ContractInput.md
+docs/CreateActualsBulk400Response.md
 docs/CreateActualsBulkRequest.md
 docs/CreateAssignmentRequest.md
 docs/CreateCheckboxCustomFieldRequest.md
@@ -89,7 +90,12 @@ docs/GetPersonCurrentContract404Response.md
 docs/GetPersonCurrentTeam200Response.md
 docs/GetPersonCurrentTeam200ResponseValuesInner.md
 docs/GetPersonHoursReport200Response.md
+docs/GetPersonReport200Response.md
+docs/GetPersonReport200ResponseMetricsInner.md
 docs/GetProjectHoursReport200Response.md
+docs/GetProjectReport200Response.md
+docs/GetProjectReport200ResponseMetricsInner.md
+docs/GetProjectReport404Response.md
 docs/GetProjectTimesheetLock200Response.md
 docs/Holiday.md
 docs/HolidayGroup.md
@@ -200,6 +206,7 @@ docs/UpdatePeopleTagRequest.md
 docs/UpdatePersonCheckboxCustomFieldRequest.md
 docs/UpdatePersonDateCustomFieldRequest.md
 docs/UpdatePersonRequest.md
+docs/UpdatePersonRequestManagersInner.md
 docs/UpdatePersonRequestTagsInner.md
 docs/UpdatePersonSelectCustomFieldRequest.md
 docs/UpdatePersonSelectCustomFieldRequestValuesInner.md
@@ -217,6 +224,7 @@ docs/UpdateProjectRoleRateRequest.md
 docs/UpdateProjectTimesheetLockRequest.md
 docs/UpdateProjectTimesheetLockRequestAnyOf.md
 docs/UpdateProjectTimesheetLockRequestAnyOf1.md
+docs/UpdateRateCardRequest.md
 docs/UpdateRoleRequest.md
 docs/UpdateSelectCustomFieldOption200Response.md
 docs/UpdateSelectCustomFieldOption200ResponseOption.md

--- a/api.ts
+++ b/api.ts
@@ -59,8 +59,8 @@ export interface Actor {
 }
 
 export const ActorTypeEnum = {
-    User: 'user',
     RunnSupport: 'runn_support',
+    User: 'user',
     Api: 'api',
     Csv: 'csv',
     Integration: 'integration',
@@ -599,6 +599,23 @@ export const ContractInputEmploymentTypeEnum = {
 
 export type ContractInputEmploymentTypeEnum = typeof ContractInputEmploymentTypeEnum[keyof typeof ContractInputEmploymentTypeEnum];
 
+export interface CreateActualsBulk400Response {
+    'error': CreateActualsBulk400ResponseErrorEnum;
+    'message': string;
+    'statusCode': CreateActualsBulk400ResponseStatusCodeEnum;
+}
+
+export const CreateActualsBulk400ResponseErrorEnum = {
+    BadRequest: 'Bad Request'
+} as const;
+
+export type CreateActualsBulk400ResponseErrorEnum = typeof CreateActualsBulk400ResponseErrorEnum[keyof typeof CreateActualsBulk400ResponseErrorEnum];
+export const CreateActualsBulk400ResponseStatusCodeEnum = {
+    NUMBER_400: 400
+} as const;
+
+export type CreateActualsBulk400ResponseStatusCodeEnum = typeof CreateActualsBulk400ResponseStatusCodeEnum[keyof typeof CreateActualsBulk400ResponseStatusCodeEnum];
+
 export interface CreateActualsBulkRequest {
     'actuals': Array<ActualInput>;
 }
@@ -708,10 +725,12 @@ export interface CreateInvitationRequest {
     'fromUser': string;
     /**
      * Permissions for editing projects. (deprecated: use manageProjectsPermission)
+     * @deprecated
      */
     'editProjectsPermission': CreateInvitationRequestEditProjectsPermissionEnum;
     /**
-     * Permissions for editing other parts of the account (people, clients, teams etc.)
+     * Permissions for editing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission)
+     * @deprecated
      */
     'editOthersPermission': CreateInvitationRequestEditOthersPermissionEnum;
     /**
@@ -719,7 +738,8 @@ export interface CreateInvitationRequest {
      */
     'manageProjectsPermission': CreateInvitationRequestManageProjectsPermissionEnum;
     /**
-     * Permissions for managing other parts of the account (people, clients, teams etc.)
+     * Permissions for managing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission)
+     * @deprecated
      */
     'manageOthersPermission': CreateInvitationRequestManageOthersPermissionEnum;
 }
@@ -775,10 +795,12 @@ export type CreateInvitationRequestManageOthersPermissionEnum = typeof CreateInv
 export interface CreateInvitationRequestAllOfAnyOf {
     /**
      * Permissions for editing projects. (deprecated: use manageProjectsPermission)
+     * @deprecated
      */
     'editProjectsPermission': CreateInvitationRequestAllOfAnyOfEditProjectsPermissionEnum;
     /**
-     * Permissions for editing other parts of the account (people, clients, teams etc.)
+     * Permissions for editing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission)
+     * @deprecated
      */
     'editOthersPermission': CreateInvitationRequestAllOfAnyOfEditOthersPermissionEnum;
 }
@@ -804,7 +826,8 @@ export interface CreateInvitationRequestAllOfAnyOf1 {
      */
     'manageProjectsPermission': CreateInvitationRequestAllOfAnyOf1ManageProjectsPermissionEnum;
     /**
-     * Permissions for managing other parts of the account (people, clients, teams etc.)
+     * Permissions for managing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission)
+     * @deprecated
      */
     'manageOthersPermission': CreateInvitationRequestAllOfAnyOf1ManageOthersPermissionEnum;
 }
@@ -834,9 +857,11 @@ export interface CreatePersonRequest {
     'firstName': string;
     'lastName': string;
     'email'?: string;
+    'teamId'?: number;
     'holidaysGroupId'?: number;
     'tags'?: Array<UpdatePersonRequestTagsInner>;
     'references'?: Array<Reference>;
+    'managers'?: Array<UpdatePersonRequestManagersInner>;
     'roleId': number;
     /**
      * Defaults to today. Format: YYYY-MM-DD
@@ -888,6 +913,7 @@ export interface CreatePlaceholderRequest {
      * Defaults to the role\'s cost per hour
      */
     'costPerHour'?: number;
+    'teamId'?: number;
     'tags'?: Array<UpdatePersonRequestTagsInner>;
 }
 export interface CreateProjectBudgetRoleRequest {
@@ -1826,9 +1852,74 @@ export interface GetPersonHoursReport200Response {
     'values': Array<ReportsHoursPeople>;
     'nextCursor': string;
 }
+export interface GetPersonReport200Response {
+    'id': number;
+    'firstName': string;
+    'lastName': string;
+    'email': string;
+    'jobTitle': string;
+    'team': string;
+    'employmentType': string;
+    'metrics': Array<GetPersonReport200ResponseMetricsInner>;
+}
+export interface GetPersonReport200ResponseMetricsInner {
+    'startDate': string;
+    'endDate': string;
+    'revenue': number;
+    'projectCosts': number;
+    'businessCosts': number;
+    'totalEffortHours': number;
+    'billableEffortHours': number;
+    'nonBillableEffortHours': number;
+    'totalUtilization': number;
+    'billableUtilization': number;
+    'contractCapacity': number;
+    'effectiveCapacity': number;
+    'overtime': number;
+    'remainingAvailability': number;
+    'timeOffHours': number;
+    'completedTimesheet': boolean;
+}
 export interface GetProjectHoursReport200Response {
     'values': Array<ReportsHoursProjects>;
     'nextCursor': string;
+}
+export interface GetProjectReport200Response {
+    'id': number;
+    'name': string;
+    'period'?: string;
+    'pricingModel': GetProjectReport200ResponsePricingModelEnum;
+    'budget': number;
+    'budgetRemaining': number;
+    'timeBudgetRemaining': number;
+    'metrics': Array<GetProjectReport200ResponseMetricsInner>;
+}
+
+export const GetProjectReport200ResponsePricingModelEnum = {
+    Tm: 'tm',
+    Fp: 'fp',
+    Nb: 'nb'
+} as const;
+
+export type GetProjectReport200ResponsePricingModelEnum = typeof GetProjectReport200ResponsePricingModelEnum[keyof typeof GetProjectReport200ResponsePricingModelEnum];
+
+export interface GetProjectReport200ResponseMetricsInner {
+    'startDate': string;
+    'endDate': string;
+    'timeMaterialsBenchmark': number;
+    'revenue': number;
+    'profit': number;
+    'costs': number;
+    /**
+     * Percentage value of the profit margin
+     */
+    'margin': number;
+    'totalEffortHours': number;
+    'billableEffortHours': number;
+    'nonBillableEffortHours': number;
+}
+export interface GetProjectReport404Response {
+    'message': string;
 }
 export interface GetProjectTimesheetLock200Response {
     'status': GetProjectTimesheetLock200ResponseStatusEnum;
@@ -1890,10 +1981,12 @@ export interface Invitation {
     'financialPermission': InvitationFinancialPermissionEnum;
     /**
      * Edit projects permission level (deprecated: use manageProjectsPermission)
+     * @deprecated
      */
     'editProjectsPermission': InvitationEditProjectsPermissionEnum;
     /**
-     * Edit others permission level
+     * Edit others permission level (deprecated: use managePeoplePermission)
+     * @deprecated
      */
     'editOthersPermission': InvitationEditOthersPermissionEnum;
     /**
@@ -3097,8 +3190,13 @@ export interface UpdatePersonRequest {
     'lastName'?: string;
     'email'?: string;
     'tags'?: Array<UpdatePersonRequestTagsInner>;
+    'teamId'?: number;
     'references'?: Array<Reference>;
     'isArchived'?: boolean;
+    'managers'?: Array<UpdatePersonRequestManagersInner>;
+}
+export interface UpdatePersonRequestManagersInner {
+    'userId': number;
 }
 export interface UpdatePersonRequestTagsInner {
     'id': number;
@@ -3281,6 +3379,22 @@ export const UpdateProjectTimesheetLockRequestAnyOf1StatusEnum = {
 
 export type UpdateProjectTimesheetLockRequestAnyOf1StatusEnum = typeof UpdateProjectTimesheetLockRequestAnyOf1StatusEnum[keyof typeof UpdateProjectTimesheetLockRequestAnyOf1StatusEnum];
 
+export interface UpdateRateCardRequest {
+    'name'?: string;
+    'description'?: string;
+    'references'?: Array<CreateRateCardRequestReferencesInner>;
+    'isBlendedRateCard'?: boolean;
+    'blendedRate'?: number;
+    'rateType'?: UpdateRateCardRequestRateTypeEnum;
+}
+
+export const UpdateRateCardRequestRateTypeEnum = {
+    Hours: 'hours',
+    Days: 'days'
+} as const;
+
+export type UpdateRateCardRequestRateTypeEnum = typeof UpdateRateCardRequestRateTypeEnum[keyof typeof UpdateRateCardRequestRateTypeEnum];
+
 export interface UpdateRoleRequest {
     'name'?: string;
     'isArchived'?: boolean;
@@ -3327,8 +3441,16 @@ export interface User {
 export interface UserPermissions {
     'type': UserPermissionsTypeEnum;
     'financial': UserPermissionsFinancialEnum;
+    /**
+     * Edit projects permission (deprecated: use manageProjects)
+     * @deprecated
+     */
     'editProjects': UserPermissionsEditProjectsEnum;
     'manageProjects': UserPermissionsManageProjectsEnum;
+    /**
+     * Edit others permission (deprecated: use managePeople)
+     * @deprecated
+     */
     'editOthers': UserPermissionsEditOthersEnum;
     'managePeople': UserPermissionsManagePeopleEnum;
     'manageAccount': boolean;
@@ -3467,7 +3589,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Add a skill to a person
+         * @summary Add a skill to a person or placeholder
          * @param {number} personId 
          * @param {AddPersonSkillAcceptVersionEnum} acceptVersion 
          * @param {AddPersonSkillRequest} addPersonSkillRequest 
@@ -3516,7 +3638,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Add project to a person
+         * @summary Add project to a person or placeholder
          * @param {number} personId 
          * @param {AddPersonToProjectAcceptVersionEnum} acceptVersion 
          * @param {AddPersonToProjectRequest} addPersonToProjectRequest 
@@ -3564,12 +3686,13 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * 
-         * @summary Add a person to a team
+         * This endpoint is deprecated. You may assign the person to a team using the `PATCH /people/:personId/` endpoint.
+         * @summary Add a person or placeholder to a team
          * @param {number} personId 
          * @param {AddPersonToTeamAcceptVersionEnum} acceptVersion 
          * @param {AddPersonToTeamRequest} addPersonToTeamRequest 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         addPersonToTeam: async (personId: number, acceptVersion: AddPersonToTeamAcceptVersionEnum, addPersonToTeamRequest: AddPersonToTeamRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
@@ -3906,13 +4029,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * Minutes values represent the total time for a day and overwrite any previous actual on the same day (for the same project/person/role/workstream). [Learn more](https://developer.runn.io/docs/actuals-notes).
          * @summary Create or update an actual
          * @param {CreateActualAcceptVersionEnum} acceptVersion 
-         * @param {ActualInput} [actualInput] 
+         * @param {ActualInput} actualInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createActual: async (acceptVersion: CreateActualAcceptVersionEnum, actualInput?: ActualInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createActual: async (acceptVersion: CreateActualAcceptVersionEnum, actualInput: ActualInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createActual', 'acceptVersion', acceptVersion)
+            // verify required parameter 'actualInput' is not null or undefined
+            assertParamExists('createActual', 'actualInput', actualInput)
             const localVarPath = `/actuals/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4084,13 +4209,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * 
          * @summary Create a client
          * @param {CreateClientAcceptVersionEnum} acceptVersion 
-         * @param {ClientInput} [clientInput] 
+         * @param {ClientInput} clientInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createClient: async (acceptVersion: CreateClientAcceptVersionEnum, clientInput?: ClientInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createClient: async (acceptVersion: CreateClientAcceptVersionEnum, clientInput: ClientInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createClient', 'acceptVersion', acceptVersion)
+            // verify required parameter 'clientInput' is not null or undefined
+            assertParamExists('createClient', 'clientInput', clientInput)
             const localVarPath = `/clients/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4217,13 +4344,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * 
          * @summary Create a holiday time off
          * @param {CreateHolidayTimeOffAcceptVersionEnum} acceptVersion 
-         * @param {TimeOffHolidayInput} [timeOffHolidayInput] 
+         * @param {TimeOffHolidayInput} timeOffHolidayInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createHolidayTimeOff: async (acceptVersion: CreateHolidayTimeOffAcceptVersionEnum, timeOffHolidayInput?: TimeOffHolidayInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createHolidayTimeOff: async (acceptVersion: CreateHolidayTimeOffAcceptVersionEnum, timeOffHolidayInput: TimeOffHolidayInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createHolidayTimeOff', 'acceptVersion', acceptVersion)
+            // verify required parameter 'timeOffHolidayInput' is not null or undefined
+            assertParamExists('createHolidayTimeOff', 'timeOffHolidayInput', timeOffHolidayInput)
             const localVarPath = `/time-offs/holidays/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4260,13 +4389,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * 
          * @summary Create an invitation for a user
          * @param {CreateInvitationAcceptVersionEnum} acceptVersion 
-         * @param {CreateInvitationRequest} [createInvitationRequest] 
+         * @param {CreateInvitationRequest} createInvitationRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createInvitation: async (acceptVersion: CreateInvitationAcceptVersionEnum, createInvitationRequest?: CreateInvitationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createInvitation: async (acceptVersion: CreateInvitationAcceptVersionEnum, createInvitationRequest: CreateInvitationRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createInvitation', 'acceptVersion', acceptVersion)
+            // verify required parameter 'createInvitationRequest' is not null or undefined
+            assertParamExists('createInvitation', 'createInvitationRequest', createInvitationRequest)
             const localVarPath = `/invitations/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4303,13 +4434,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          *  #### Create or Update  This endpoint may return an existing time off if the new time off is a subset of an existing one.  #### Automatic Merging  If one or more existing time offs overlap with the specified start/end date, they will be automatically merged.  #### Partial Time Offs  If the `minutesPerDay` field is provided, automatic merging will only occur if any overlapping time off has the same `minutesPerDay` value. If the `minutesPerDay` value differs, the request will fail.
          * @summary Create a leave time off
          * @param {CreateLeaveTimeOffAcceptVersionEnum} acceptVersion 
-         * @param {TimeOffLeaveInput} [timeOffLeaveInput] 
+         * @param {TimeOffLeaveInput} timeOffLeaveInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createLeaveTimeOff: async (acceptVersion: CreateLeaveTimeOffAcceptVersionEnum, timeOffLeaveInput?: TimeOffLeaveInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createLeaveTimeOff: async (acceptVersion: CreateLeaveTimeOffAcceptVersionEnum, timeOffLeaveInput: TimeOffLeaveInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createLeaveTimeOff', 'acceptVersion', acceptVersion)
+            // verify required parameter 'timeOffLeaveInput' is not null or undefined
+            assertParamExists('createLeaveTimeOff', 'timeOffLeaveInput', timeOffLeaveInput)
             const localVarPath = `/time-offs/leave/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4531,15 +4664,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Add a new contract to a person
          * @param {number} personId 
          * @param {CreatePersonContractAcceptVersionEnum} acceptVersion 
-         * @param {ContractInput} [contractInput] 
+         * @param {ContractInput} contractInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createPersonContract: async (personId: number, acceptVersion: CreatePersonContractAcceptVersionEnum, contractInput?: ContractInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createPersonContract: async (personId: number, acceptVersion: CreatePersonContractAcceptVersionEnum, contractInput: ContractInput, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'personId' is not null or undefined
             assertParamExists('createPersonContract', 'personId', personId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createPersonContract', 'acceptVersion', acceptVersion)
+            // verify required parameter 'contractInput' is not null or undefined
+            assertParamExists('createPersonContract', 'contractInput', contractInput)
             const localVarPath = `/people/{personId}/contracts/`
                 .replace(`{${"personId"}}`, encodeURIComponent(String(personId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -4622,13 +4757,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * 
          * @summary Create a project
          * @param {CreateProjectAcceptVersionEnum} acceptVersion 
-         * @param {CreateProjectRequest} [createProjectRequest] 
+         * @param {CreateProjectRequest} createProjectRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createProject: async (acceptVersion: CreateProjectAcceptVersionEnum, createProjectRequest?: CreateProjectRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createProject: async (acceptVersion: CreateProjectAcceptVersionEnum, createProjectRequest: CreateProjectRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createProject', 'acceptVersion', acceptVersion)
+            // verify required parameter 'createProjectRequest' is not null or undefined
+            assertParamExists('createProject', 'createProjectRequest', createProjectRequest)
             const localVarPath = `/projects/`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -4666,15 +4803,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Create a project budget role
          * @param {number} projectId 
          * @param {CreateProjectBudgetRoleAcceptVersionEnum} acceptVersion 
-         * @param {CreateProjectBudgetRoleRequest} [createProjectBudgetRoleRequest] 
+         * @param {CreateProjectBudgetRoleRequest} createProjectBudgetRoleRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createProjectBudgetRole: async (projectId: number, acceptVersion: CreateProjectBudgetRoleAcceptVersionEnum, createProjectBudgetRoleRequest?: CreateProjectBudgetRoleRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createProjectBudgetRole: async (projectId: number, acceptVersion: CreateProjectBudgetRoleAcceptVersionEnum, createProjectBudgetRoleRequest: CreateProjectBudgetRoleRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'projectId' is not null or undefined
             assertParamExists('createProjectBudgetRole', 'projectId', projectId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('createProjectBudgetRole', 'acceptVersion', acceptVersion)
+            // verify required parameter 'createProjectBudgetRoleRequest' is not null or undefined
+            assertParamExists('createProjectBudgetRole', 'createProjectBudgetRoleRequest', createProjectBudgetRoleRequest)
             const localVarPath = `/projects/{projectId}/budget-roles/`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -5711,8 +5850,8 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * Delete a person by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
-         * @summary Delete a person
+         * Delete a person or placeholder by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
+         * @summary Delete a person or placeholder
          * @param {boolean} force 
          * @param {number} personId 
          * @param {DeletePersonAcceptVersionEnum} acceptVersion 
@@ -6615,7 +6754,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Show a person
+         * @summary Show a person or placeholder
          * @param {number} personId 
          * @param {GetPersonAcceptVersionEnum} acceptVersion 
          * @param {*} [options] Override http request option.
@@ -6702,13 +6841,14 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * 
-         * @summary Show current team
+         * This endpoint is deprecated. You may view the current team for a person using the `GET /people/:personId/` endpoint.
+         * @summary Show current team for a person or placeholder
          * @param {number} personId 
          * @param {GetPersonCurrentTeamAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
          * @param {number} [limit] The number of results per page
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         getPersonCurrentTeam: async (personId: number, acceptVersion: GetPersonCurrentTeamAcceptVersionEnum, cursor?: string, limit?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
@@ -6807,6 +6947,62 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
                 localVarQueryParameter['endDate'] = (endDate as any instanceof Date) ?
                     (endDate as any).toISOString().substring(0,10) :
                     endDate;
+            }
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            if (acceptVersion != null) {
+                localVarHeaderParameter['accept-version'] = String(acceptVersion);
+            }
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Get a report for a person containing data from the People Overview Report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+         * @summary Show metrics (beta)
+         * @param {number} personId 
+         * @param {GetPersonReportAcceptVersionEnum} acceptVersion 
+         * @param {string} [startDate] The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD
+         * @param {GetPersonReportPeriodTypeEnum} [periodType] The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPersonReport: async (personId: number, acceptVersion: GetPersonReportAcceptVersionEnum, startDate?: string, periodType?: GetPersonReportPeriodTypeEnum, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'personId' is not null or undefined
+            assertParamExists('getPersonReport', 'personId', personId)
+            // verify required parameter 'acceptVersion' is not null or undefined
+            assertParamExists('getPersonReport', 'acceptVersion', acceptVersion)
+            const localVarPath = `/reports/people/{personId}/`
+                .replace(`{${"personId"}}`, encodeURIComponent(String(personId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (startDate !== undefined) {
+                localVarQueryParameter['startDate'] = (startDate as any instanceof Date) ?
+                    (startDate as any).toISOString().substring(0,10) :
+                    startDate;
+            }
+
+            if (periodType !== undefined) {
+                localVarQueryParameter['periodType'] = periodType;
             }
 
             localVarHeaderParameter['Accept'] = 'application/json';
@@ -7064,6 +7260,62 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             // authentication bearerAuth required
             // http bearer authentication required
             await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            if (acceptVersion != null) {
+                localVarHeaderParameter['accept-version'] = String(acceptVersion);
+            }
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Get a report for a project containing data from the Project Overview report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+         * @summary Show metrics (beta)
+         * @param {number} projectId 
+         * @param {GetProjectReportAcceptVersionEnum} acceptVersion 
+         * @param {string} [startDate] The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD
+         * @param {GetProjectReportPeriodTypeEnum} [periodType] The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. If not provided, the report will be for the Overview report (all inclusive).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getProjectReport: async (projectId: number, acceptVersion: GetProjectReportAcceptVersionEnum, startDate?: string, periodType?: GetProjectReportPeriodTypeEnum, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'projectId' is not null or undefined
+            assertParamExists('getProjectReport', 'projectId', projectId)
+            // verify required parameter 'acceptVersion' is not null or undefined
+            assertParamExists('getProjectReport', 'acceptVersion', acceptVersion)
+            const localVarPath = `/reports/projects/{projectId}/`
+                .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            if (startDate !== undefined) {
+                localVarQueryParameter['startDate'] = (startDate as any instanceof Date) ?
+                    (startDate as any).toISOString().substring(0,10) :
+                    startDate;
+            }
+
+            if (periodType !== undefined) {
+                localVarQueryParameter['periodType'] = periodType;
+            }
 
             localVarHeaderParameter['Accept'] = 'application/json';
 
@@ -8681,7 +8933,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {string} [email] If provided, will only return people with an email that are a substring of this value (case-insensitive).
          * @param {string} [firstName] If provided, will only return people with a first name that is a substring of this value (case-insensitive).
          * @param {string} [lastName] If provided, will only return people with a last name that is a substring of this value (case-insensitive).
-         * @param {ModifiedAfter} [modifiedAfter] If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A person is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a person include changing first name, last name, email, references, tags and archiving. A person is not considered modified just because another object it is associated with is changed (e.g. a contract, project or an assignment).
+         * @param {ModifiedAfter} [modifiedAfter] 
          * @param {string} [externalId] External ID value
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -8939,7 +9191,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {string} [cursor] Cursor for paginated requests
          * @param {number} [limit] The number of results per page
          * @param {boolean} [includePlaceholders] 
-         * @param {ModifiedAfter} [modifiedAfter] If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ.
+         * @param {ModifiedAfter} [modifiedAfter] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -9134,7 +9386,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary List assignments for a person
+         * @summary List assignments for a person or placeholder
          * @param {number} personId 
          * @param {ListPersonAssignmentsAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -9381,7 +9633,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary List projects for a person
+         * @summary List projects for a person or placeholder
          * @param {number} personId 
          * @param {ListPersonProjectsAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -9546,7 +9798,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary List skills for a person
+         * @summary List skills for a person or placeholder
          * @param {number} personId 
          * @param {ListPersonSkillsAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -9663,7 +9915,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * 
+         * Note: The /people/_* endpoints also allows getting information on placeholders when using the `includePlaceholders` query parameter.
          * @summary List placeholders
          * @param {ListPlaceholdersAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -10768,7 +11020,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} [limit] The number of results per page
          * @param {ListProjectsSortByEnum} [sortBy] Field to sort by: createdAt or updatedAt or id
          * @param {ListProjectsOrderEnum} [order] Sort order: asc or desc
-         * @param {ModifiedAfter} [modifiedAfter] If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A project is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a project include changing the name, client, status, pricing model, rate type , team, budget, expenses budget, references, and archiving. A project is not considered modified just because another object it is associated with is changed (e.g. actuals, assignments, budget roles, custom fields, milestones, notes, other expenses, people, people requests, phases, rates, timesheet locks &amp; workstreams).
+         * @param {ModifiedAfter} [modifiedAfter] 
          * @param {string} [externalId] External ID value
          * @param {string} [name] Case-insensitive substring match on project name (e.g. &#x60;Acme&#x60;).
          * @param {*} [options] Override http request option.
@@ -11646,14 +11898,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             };
         },
         /**
-         * 
-         * @summary Remove a person from a team
+         * This endpoint is deprecated. You may remove the person from a team using the `PATCH /people/:personId/` endpoint.
+         * @summary Remove a person or placeholder from a team
          * @param {number} personId 
          * @param {number} teamId 
          * @param {RemovePersonFromTeamAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
          * @param {number} [limit] The number of results per page
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         removePersonFromTeam: async (personId: number, teamId: number, acceptVersion: RemovePersonFromTeamAcceptVersionEnum, cursor?: string, limit?: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
@@ -11705,7 +11958,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Remove a skill from a person
+         * @summary Remove a skill from a person or placeholder
          * @param {number} personId 
          * @param {number} skillId 
          * @param {RemovePersonSkillAcceptVersionEnum} acceptVersion 
@@ -11995,13 +12248,15 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * Returns Actual with updated minutes. Creates a new actual when there is none to update [Learn more](https://developer.runn.io/docs/actuals-notes).
          * @summary Update an actual
          * @param {UpdateActualTimeEntryAcceptVersionEnum} acceptVersion 
-         * @param {ActualTimeEntry} [actualTimeEntry] 
+         * @param {ActualTimeEntry} actualTimeEntry 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateActualTimeEntry: async (acceptVersion: UpdateActualTimeEntryAcceptVersionEnum, actualTimeEntry?: ActualTimeEntry, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateActualTimeEntry: async (acceptVersion: UpdateActualTimeEntryAcceptVersionEnum, actualTimeEntry: ActualTimeEntry, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateActualTimeEntry', 'acceptVersion', acceptVersion)
+            // verify required parameter 'actualTimeEntry' is not null or undefined
+            assertParamExists('updateActualTimeEntry', 'actualTimeEntry', actualTimeEntry)
             const localVarPath = `/actuals/time-entry`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -12039,15 +12294,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a checkbox custom field
          * @param {number} checkboxFieldId 
          * @param {UpdateCheckboxCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateCheckboxCustomFieldRequest} [updateCheckboxCustomFieldRequest] 
+         * @param {UpdateCheckboxCustomFieldRequest} updateCheckboxCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateCheckboxCustomField: async (checkboxFieldId: number, acceptVersion: UpdateCheckboxCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateCheckboxCustomField: async (checkboxFieldId: number, acceptVersion: UpdateCheckboxCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'checkboxFieldId' is not null or undefined
             assertParamExists('updateCheckboxCustomField', 'checkboxFieldId', checkboxFieldId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateCheckboxCustomField', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateCheckboxCustomFieldRequest' is not null or undefined
+            assertParamExists('updateCheckboxCustomField', 'updateCheckboxCustomFieldRequest', updateCheckboxCustomFieldRequest)
             const localVarPath = `/custom-fields/checkbox/{checkboxFieldId}`
                 .replace(`{${"checkboxFieldId"}}`, encodeURIComponent(String(checkboxFieldId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -12086,15 +12343,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a client
          * @param {number} clientId 
          * @param {UpdateClientAcceptVersionEnum} acceptVersion 
-         * @param {UpdateClientRequest} [updateClientRequest] 
+         * @param {UpdateClientRequest} updateClientRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateClient: async (clientId: number, acceptVersion: UpdateClientAcceptVersionEnum, updateClientRequest?: UpdateClientRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateClient: async (clientId: number, acceptVersion: UpdateClientAcceptVersionEnum, updateClientRequest: UpdateClientRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'clientId' is not null or undefined
             assertParamExists('updateClient', 'clientId', clientId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateClient', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateClientRequest' is not null or undefined
+            assertParamExists('updateClient', 'updateClientRequest', updateClientRequest)
             const localVarPath = `/clients/{clientId}`
                 .replace(`{${"clientId"}}`, encodeURIComponent(String(clientId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -12133,15 +12392,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a contract
          * @param {number} contractId 
          * @param {UpdateContractAcceptVersionEnum} acceptVersion 
-         * @param {UpdateContractRequest} [updateContractRequest] 
+         * @param {UpdateContractRequest} updateContractRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateContract: async (contractId: number, acceptVersion: UpdateContractAcceptVersionEnum, updateContractRequest?: UpdateContractRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateContract: async (contractId: number, acceptVersion: UpdateContractAcceptVersionEnum, updateContractRequest: UpdateContractRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'contractId' is not null or undefined
             assertParamExists('updateContract', 'contractId', contractId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateContract', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateContractRequest' is not null or undefined
+            assertParamExists('updateContract', 'updateContractRequest', updateContractRequest)
             const localVarPath = `/contracts/{contractId}`
                 .replace(`{${"contractId"}}`, encodeURIComponent(String(contractId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -12180,15 +12441,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a date custom field
          * @param {number} dateFieldId 
          * @param {UpdateDateCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateDateCustomFieldRequest} [updateDateCustomFieldRequest] 
+         * @param {UpdateDateCustomFieldRequest} updateDateCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateDateCustomField: async (dateFieldId: number, acceptVersion: UpdateDateCustomFieldAcceptVersionEnum, updateDateCustomFieldRequest?: UpdateDateCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateDateCustomField: async (dateFieldId: number, acceptVersion: UpdateDateCustomFieldAcceptVersionEnum, updateDateCustomFieldRequest: UpdateDateCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'dateFieldId' is not null or undefined
             assertParamExists('updateDateCustomField', 'dateFieldId', dateFieldId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateDateCustomField', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateDateCustomFieldRequest' is not null or undefined
+            assertParamExists('updateDateCustomField', 'updateDateCustomFieldRequest', updateDateCustomFieldRequest)
             const localVarPath = `/custom-fields/date/{dateFieldId}`
                 .replace(`{${"dateFieldId"}}`, encodeURIComponent(String(dateFieldId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -12273,18 +12536,20 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * To add a new role or job title to a person, see POST /people/{personId}/contracts
-         * @summary Update a person
+         * @summary Update a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonAcceptVersionEnum} acceptVersion 
-         * @param {UpdatePersonRequest} [updatePersonRequest] 
+         * @param {UpdatePersonRequest} updatePersonRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updatePerson: async (personId: number, acceptVersion: UpdatePersonAcceptVersionEnum, updatePersonRequest?: UpdatePersonRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updatePerson: async (personId: number, acceptVersion: UpdatePersonAcceptVersionEnum, updatePersonRequest: UpdatePersonRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'personId' is not null or undefined
             assertParamExists('updatePerson', 'personId', personId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updatePerson', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updatePersonRequest' is not null or undefined
+            assertParamExists('updatePerson', 'updatePersonRequest', updatePersonRequest)
             const localVarPath = `/people/{personId}`
                 .replace(`{${"personId"}}`, encodeURIComponent(String(personId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -12320,7 +12585,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Add a checkbox custom value to a person
+         * @summary Add a checkbox custom value to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonCheckboxCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonCheckboxCustomFieldRequest} updatePersonCheckboxCustomFieldRequest 
@@ -12369,7 +12634,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Add a date custom value to a person
+         * @summary Add a date custom value to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonDateCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonDateCustomFieldRequest} updatePersonDateCustomFieldRequest 
@@ -12418,7 +12683,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Add custom select options to a person
+         * @summary Add custom select options to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonSelectCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonSelectCustomFieldRequest} updatePersonSelectCustomFieldRequest 
@@ -12467,7 +12732,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Update a skill for a person
+         * @summary Update a skill for a person or placeholder
          * @param {number} personId 
          * @param {number} skillId 
          * @param {UpdatePersonSkillAcceptVersionEnum} acceptVersion 
@@ -12520,7 +12785,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Add a text custom value to a person
+         * @summary Add a text custom value to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonTextCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonTextCustomFieldRequest} updatePersonTextCustomFieldRequest 
@@ -12572,15 +12837,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a project
          * @param {number} projectId 
          * @param {UpdateProjectAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectRequest} [updateProjectRequest] 
+         * @param {UpdateProjectRequest} updateProjectRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateProject: async (projectId: number, acceptVersion: UpdateProjectAcceptVersionEnum, updateProjectRequest?: UpdateProjectRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateProject: async (projectId: number, acceptVersion: UpdateProjectAcceptVersionEnum, updateProjectRequest: UpdateProjectRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'projectId' is not null or undefined
             assertParamExists('updateProject', 'projectId', projectId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateProject', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateProjectRequest' is not null or undefined
+            assertParamExists('updateProject', 'updateProjectRequest', updateProjectRequest)
             const localVarPath = `/projects/{projectId}`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -12620,17 +12887,19 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} projectId 
          * @param {number} roleId 
          * @param {UpdateProjectBudgetRoleAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectBudgetRoleRequest} [updateProjectBudgetRoleRequest] 
+         * @param {UpdateProjectBudgetRoleRequest} updateProjectBudgetRoleRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateProjectBudgetRole: async (projectId: number, roleId: number, acceptVersion: UpdateProjectBudgetRoleAcceptVersionEnum, updateProjectBudgetRoleRequest?: UpdateProjectBudgetRoleRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateProjectBudgetRole: async (projectId: number, roleId: number, acceptVersion: UpdateProjectBudgetRoleAcceptVersionEnum, updateProjectBudgetRoleRequest: UpdateProjectBudgetRoleRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'projectId' is not null or undefined
             assertParamExists('updateProjectBudgetRole', 'projectId', projectId)
             // verify required parameter 'roleId' is not null or undefined
             assertParamExists('updateProjectBudgetRole', 'roleId', roleId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateProjectBudgetRole', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateProjectBudgetRoleRequest' is not null or undefined
+            assertParamExists('updateProjectBudgetRole', 'updateProjectBudgetRoleRequest', updateProjectBudgetRoleRequest)
             const localVarPath = `/projects/{projectId}/budget-roles/{roleId}`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)))
                 .replace(`{${"roleId"}}`, encodeURIComponent(String(roleId)));
@@ -12769,17 +13038,19 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} projectId 
          * @param {number} milestoneId 
          * @param {UpdateProjectMilestoneAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectMilestoneRequest} [updateProjectMilestoneRequest] 
+         * @param {UpdateProjectMilestoneRequest} updateProjectMilestoneRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateProjectMilestone: async (projectId: number, milestoneId: number, acceptVersion: UpdateProjectMilestoneAcceptVersionEnum, updateProjectMilestoneRequest?: UpdateProjectMilestoneRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateProjectMilestone: async (projectId: number, milestoneId: number, acceptVersion: UpdateProjectMilestoneAcceptVersionEnum, updateProjectMilestoneRequest: UpdateProjectMilestoneRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'projectId' is not null or undefined
             assertParamExists('updateProjectMilestone', 'projectId', projectId)
             // verify required parameter 'milestoneId' is not null or undefined
             assertParamExists('updateProjectMilestone', 'milestoneId', milestoneId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateProjectMilestone', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateProjectMilestoneRequest' is not null or undefined
+            assertParamExists('updateProjectMilestone', 'updateProjectMilestoneRequest', updateProjectMilestoneRequest)
             const localVarPath = `/projects/{projectId}/milestones/{milestoneId}`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)))
                 .replace(`{${"milestoneId"}}`, encodeURIComponent(String(milestoneId)));
@@ -12820,17 +13091,19 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} projectId Unique identifier for the project the expense is for.
          * @param {number} otherExpenseId Unique identifier for the other expense to update.
          * @param {UpdateProjectOtherExpenseAcceptVersionEnum} acceptVersion 
-         * @param {ProjectOtherExpense1} [projectOtherExpense1] A non-labour expense for a project.
+         * @param {ProjectOtherExpense1} projectOtherExpense1 A non-labour expense for a project.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateProjectOtherExpense: async (projectId: number, otherExpenseId: number, acceptVersion: UpdateProjectOtherExpenseAcceptVersionEnum, projectOtherExpense1?: ProjectOtherExpense1, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateProjectOtherExpense: async (projectId: number, otherExpenseId: number, acceptVersion: UpdateProjectOtherExpenseAcceptVersionEnum, projectOtherExpense1: ProjectOtherExpense1, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'projectId' is not null or undefined
             assertParamExists('updateProjectOtherExpense', 'projectId', projectId)
             // verify required parameter 'otherExpenseId' is not null or undefined
             assertParamExists('updateProjectOtherExpense', 'otherExpenseId', otherExpenseId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateProjectOtherExpense', 'acceptVersion', acceptVersion)
+            // verify required parameter 'projectOtherExpense1' is not null or undefined
+            assertParamExists('updateProjectOtherExpense', 'projectOtherExpense1', projectOtherExpense1)
             const localVarPath = `/projects/{projectId}/other-expenses/{otherExpenseId}/`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)))
                 .replace(`{${"otherExpenseId"}}`, encodeURIComponent(String(otherExpenseId)));
@@ -12924,17 +13197,19 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} projectId 
          * @param {number} phaseId 
          * @param {UpdateProjectPhaseAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectPhaseRequest} [updateProjectPhaseRequest] 
+         * @param {UpdateProjectPhaseRequest} updateProjectPhaseRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateProjectPhase: async (projectId: number, phaseId: number, acceptVersion: UpdateProjectPhaseAcceptVersionEnum, updateProjectPhaseRequest?: UpdateProjectPhaseRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateProjectPhase: async (projectId: number, phaseId: number, acceptVersion: UpdateProjectPhaseAcceptVersionEnum, updateProjectPhaseRequest: UpdateProjectPhaseRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'projectId' is not null or undefined
             assertParamExists('updateProjectPhase', 'projectId', projectId)
             // verify required parameter 'phaseId' is not null or undefined
             assertParamExists('updateProjectPhase', 'phaseId', phaseId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateProjectPhase', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateProjectPhaseRequest' is not null or undefined
+            assertParamExists('updateProjectPhase', 'updateProjectPhaseRequest', updateProjectPhaseRequest)
             const localVarPath = `/projects/{projectId}/phases/{phaseId}`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)))
                 .replace(`{${"phaseId"}}`, encodeURIComponent(String(phaseId)));
@@ -13174,15 +13449,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a timesheet lock for a project
          * @param {number} projectId 
          * @param {UpdateProjectTimesheetLockAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectTimesheetLockRequest} [updateProjectTimesheetLockRequest] 
+         * @param {UpdateProjectTimesheetLockRequest} updateProjectTimesheetLockRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateProjectTimesheetLock: async (projectId: number, acceptVersion: UpdateProjectTimesheetLockAcceptVersionEnum, updateProjectTimesheetLockRequest?: UpdateProjectTimesheetLockRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateProjectTimesheetLock: async (projectId: number, acceptVersion: UpdateProjectTimesheetLockAcceptVersionEnum, updateProjectTimesheetLockRequest: UpdateProjectTimesheetLockRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'projectId' is not null or undefined
             assertParamExists('updateProjectTimesheetLock', 'projectId', projectId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateProjectTimesheetLock', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateProjectTimesheetLockRequest' is not null or undefined
+            assertParamExists('updateProjectTimesheetLock', 'updateProjectTimesheetLockRequest', updateProjectTimesheetLockRequest)
             const localVarPath = `/projects/{projectId}/timesheet-lock/`
                 .replace(`{${"projectId"}}`, encodeURIComponent(String(projectId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -13218,18 +13495,69 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @summary Update a role
-         * @param {number} roleId 
-         * @param {UpdateRoleAcceptVersionEnum} acceptVersion 
-         * @param {UpdateRoleRequest} [updateRoleRequest] 
+         * @summary Update a rate card
+         * @param {number} rateCardId 
+         * @param {UpdateRateCardAcceptVersionEnum} acceptVersion 
+         * @param {UpdateRateCardRequest} updateRateCardRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateRole: async (roleId: number, acceptVersion: UpdateRoleAcceptVersionEnum, updateRoleRequest?: UpdateRoleRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateRateCard: async (rateCardId: number, acceptVersion: UpdateRateCardAcceptVersionEnum, updateRateCardRequest: UpdateRateCardRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'rateCardId' is not null or undefined
+            assertParamExists('updateRateCard', 'rateCardId', rateCardId)
+            // verify required parameter 'acceptVersion' is not null or undefined
+            assertParamExists('updateRateCard', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateRateCardRequest' is not null or undefined
+            assertParamExists('updateRateCard', 'updateRateCardRequest', updateRateCardRequest)
+            const localVarPath = `/rate-cards/{rateCardId}`
+                .replace(`{${"rateCardId"}}`, encodeURIComponent(String(rateCardId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            if (acceptVersion != null) {
+                localVarHeaderParameter['accept-version'] = String(acceptVersion);
+            }
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(updateRateCardRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Update a role
+         * @param {number} roleId 
+         * @param {UpdateRoleAcceptVersionEnum} acceptVersion 
+         * @param {UpdateRoleRequest} updateRoleRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateRole: async (roleId: number, acceptVersion: UpdateRoleAcceptVersionEnum, updateRoleRequest: UpdateRoleRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'roleId' is not null or undefined
             assertParamExists('updateRole', 'roleId', roleId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateRole', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateRoleRequest' is not null or undefined
+            assertParamExists('updateRole', 'updateRoleRequest', updateRoleRequest)
             const localVarPath = `/roles/{roleId}`
                 .replace(`{${"roleId"}}`, encodeURIComponent(String(roleId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -13268,15 +13596,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a select custom field
          * @param {number} selectFieldId 
          * @param {UpdateSelectCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateCheckboxCustomFieldRequest} [updateCheckboxCustomFieldRequest] 
+         * @param {UpdateCheckboxCustomFieldRequest} updateCheckboxCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateSelectCustomField: async (selectFieldId: number, acceptVersion: UpdateSelectCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateSelectCustomField: async (selectFieldId: number, acceptVersion: UpdateSelectCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'selectFieldId' is not null or undefined
             assertParamExists('updateSelectCustomField', 'selectFieldId', selectFieldId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateSelectCustomField', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateCheckboxCustomFieldRequest' is not null or undefined
+            assertParamExists('updateSelectCustomField', 'updateCheckboxCustomFieldRequest', updateCheckboxCustomFieldRequest)
             const localVarPath = `/custom-fields/select/{selectFieldId}`
                 .replace(`{${"selectFieldId"}}`, encodeURIComponent(String(selectFieldId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -13466,15 +13796,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a text custom field
          * @param {number} textFieldId 
          * @param {UpdateTextCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateCheckboxCustomFieldRequest} [updateCheckboxCustomFieldRequest] 
+         * @param {UpdateCheckboxCustomFieldRequest} updateCheckboxCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateTextCustomField: async (textFieldId: number, acceptVersion: UpdateTextCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateTextCustomField: async (textFieldId: number, acceptVersion: UpdateTextCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'textFieldId' is not null or undefined
             assertParamExists('updateTextCustomField', 'textFieldId', textFieldId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateTextCustomField', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateCheckboxCustomFieldRequest' is not null or undefined
+            assertParamExists('updateTextCustomField', 'updateCheckboxCustomFieldRequest', updateCheckboxCustomFieldRequest)
             const localVarPath = `/custom-fields/text/{textFieldId}`
                 .replace(`{${"textFieldId"}}`, encodeURIComponent(String(textFieldId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -13513,15 +13845,17 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
          * @summary Update a workstream
          * @param {number} workstreamId 
          * @param {UpdateWorkstreamAcceptVersionEnum} acceptVersion 
-         * @param {UpdateWorkstreamRequest} [updateWorkstreamRequest] 
+         * @param {UpdateWorkstreamRequest} updateWorkstreamRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateWorkstream: async (workstreamId: number, acceptVersion: UpdateWorkstreamAcceptVersionEnum, updateWorkstreamRequest?: UpdateWorkstreamRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateWorkstream: async (workstreamId: number, acceptVersion: UpdateWorkstreamAcceptVersionEnum, updateWorkstreamRequest: UpdateWorkstreamRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'workstreamId' is not null or undefined
             assertParamExists('updateWorkstream', 'workstreamId', workstreamId)
             // verify required parameter 'acceptVersion' is not null or undefined
             assertParamExists('updateWorkstream', 'acceptVersion', acceptVersion)
+            // verify required parameter 'updateWorkstreamRequest' is not null or undefined
+            assertParamExists('updateWorkstream', 'updateWorkstreamRequest', updateWorkstreamRequest)
             const localVarPath = `/workstreams/{workstreamId}/`
                 .replace(`{${"workstreamId"}}`, encodeURIComponent(String(workstreamId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
@@ -13581,7 +13915,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Add a skill to a person
+         * @summary Add a skill to a person or placeholder
          * @param {number} personId 
          * @param {AddPersonSkillAcceptVersionEnum} acceptVersion 
          * @param {AddPersonSkillRequest} addPersonSkillRequest 
@@ -13596,7 +13930,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Add project to a person
+         * @summary Add project to a person or placeholder
          * @param {number} personId 
          * @param {AddPersonToProjectAcceptVersionEnum} acceptVersion 
          * @param {AddPersonToProjectRequest} addPersonToProjectRequest 
@@ -13610,12 +13944,13 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
-         * @summary Add a person to a team
+         * This endpoint is deprecated. You may assign the person to a team using the `PATCH /people/:personId/` endpoint.
+         * @summary Add a person or placeholder to a team
          * @param {number} personId 
          * @param {AddPersonToTeamAcceptVersionEnum} acceptVersion 
          * @param {AddPersonToTeamRequest} addPersonToTeamRequest 
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         async addPersonToTeam(personId: number, acceptVersion: AddPersonToTeamAcceptVersionEnum, addPersonToTeamRequest: AddPersonToTeamRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
@@ -13718,11 +14053,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * Minutes values represent the total time for a day and overwrite any previous actual on the same day (for the same project/person/role/workstream). [Learn more](https://developer.runn.io/docs/actuals-notes).
          * @summary Create or update an actual
          * @param {CreateActualAcceptVersionEnum} acceptVersion 
-         * @param {ActualInput} [actualInput] 
+         * @param {ActualInput} actualInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createActual(acceptVersion: CreateActualAcceptVersionEnum, actualInput?: ActualInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Actual>> {
+        async createActual(acceptVersion: CreateActualAcceptVersionEnum, actualInput: ActualInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Actual>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createActual(acceptVersion, actualInput, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createActual']?.[localVarOperationServerIndex]?.url;
@@ -13774,11 +14109,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * 
          * @summary Create a client
          * @param {CreateClientAcceptVersionEnum} acceptVersion 
-         * @param {ClientInput} [clientInput] 
+         * @param {ClientInput} clientInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createClient(acceptVersion: CreateClientAcceptVersionEnum, clientInput?: ClientInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+        async createClient(acceptVersion: CreateClientAcceptVersionEnum, clientInput: ClientInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createClient(acceptVersion, clientInput, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createClient']?.[localVarOperationServerIndex]?.url;
@@ -13816,11 +14151,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * 
          * @summary Create a holiday time off
          * @param {CreateHolidayTimeOffAcceptVersionEnum} acceptVersion 
-         * @param {TimeOffHolidayInput} [timeOffHolidayInput] 
+         * @param {TimeOffHolidayInput} timeOffHolidayInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createHolidayTimeOff(acceptVersion: CreateHolidayTimeOffAcceptVersionEnum, timeOffHolidayInput?: TimeOffHolidayInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimeOff>> {
+        async createHolidayTimeOff(acceptVersion: CreateHolidayTimeOffAcceptVersionEnum, timeOffHolidayInput: TimeOffHolidayInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimeOff>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createHolidayTimeOff(acceptVersion, timeOffHolidayInput, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createHolidayTimeOff']?.[localVarOperationServerIndex]?.url;
@@ -13830,11 +14165,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * 
          * @summary Create an invitation for a user
          * @param {CreateInvitationAcceptVersionEnum} acceptVersion 
-         * @param {CreateInvitationRequest} [createInvitationRequest] 
+         * @param {CreateInvitationRequest} createInvitationRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createInvitation(acceptVersion: CreateInvitationAcceptVersionEnum, createInvitationRequest?: CreateInvitationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Invitation>> {
+        async createInvitation(acceptVersion: CreateInvitationAcceptVersionEnum, createInvitationRequest: CreateInvitationRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Invitation>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createInvitation(acceptVersion, createInvitationRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createInvitation']?.[localVarOperationServerIndex]?.url;
@@ -13844,11 +14179,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          *  #### Create or Update  This endpoint may return an existing time off if the new time off is a subset of an existing one.  #### Automatic Merging  If one or more existing time offs overlap with the specified start/end date, they will be automatically merged.  #### Partial Time Offs  If the `minutesPerDay` field is provided, automatic merging will only occur if any overlapping time off has the same `minutesPerDay` value. If the `minutesPerDay` value differs, the request will fail.
          * @summary Create a leave time off
          * @param {CreateLeaveTimeOffAcceptVersionEnum} acceptVersion 
-         * @param {TimeOffLeaveInput} [timeOffLeaveInput] 
+         * @param {TimeOffLeaveInput} timeOffLeaveInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createLeaveTimeOff(acceptVersion: CreateLeaveTimeOffAcceptVersionEnum, timeOffLeaveInput?: TimeOffLeaveInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimeOff>> {
+        async createLeaveTimeOff(acceptVersion: CreateLeaveTimeOffAcceptVersionEnum, timeOffLeaveInput: TimeOffLeaveInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<TimeOff>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createLeaveTimeOff(acceptVersion, timeOffLeaveInput, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createLeaveTimeOff']?.[localVarOperationServerIndex]?.url;
@@ -13916,11 +14251,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Add a new contract to a person
          * @param {number} personId 
          * @param {CreatePersonContractAcceptVersionEnum} acceptVersion 
-         * @param {ContractInput} [contractInput] 
+         * @param {ContractInput} contractInput 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createPersonContract(personId: number, acceptVersion: CreatePersonContractAcceptVersionEnum, contractInput?: ContractInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Contract>> {
+        async createPersonContract(personId: number, acceptVersion: CreatePersonContractAcceptVersionEnum, contractInput: ContractInput, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Contract>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createPersonContract(personId, acceptVersion, contractInput, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createPersonContract']?.[localVarOperationServerIndex]?.url;
@@ -13944,11 +14279,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * 
          * @summary Create a project
          * @param {CreateProjectAcceptVersionEnum} acceptVersion 
-         * @param {CreateProjectRequest} [createProjectRequest] 
+         * @param {CreateProjectRequest} createProjectRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createProject(acceptVersion: CreateProjectAcceptVersionEnum, createProjectRequest?: CreateProjectRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Project>> {
+        async createProject(acceptVersion: CreateProjectAcceptVersionEnum, createProjectRequest: CreateProjectRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Project>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createProject(acceptVersion, createProjectRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createProject']?.[localVarOperationServerIndex]?.url;
@@ -13959,11 +14294,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Create a project budget role
          * @param {number} projectId 
          * @param {CreateProjectBudgetRoleAcceptVersionEnum} acceptVersion 
-         * @param {CreateProjectBudgetRoleRequest} [createProjectBudgetRoleRequest] 
+         * @param {CreateProjectBudgetRoleRequest} createProjectBudgetRoleRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async createProjectBudgetRole(projectId: number, acceptVersion: CreateProjectBudgetRoleAcceptVersionEnum, createProjectBudgetRoleRequest?: CreateProjectBudgetRoleRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+        async createProjectBudgetRole(projectId: number, acceptVersion: CreateProjectBudgetRoleAcceptVersionEnum, createProjectBudgetRoleRequest: CreateProjectBudgetRoleRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.createProjectBudgetRole(projectId, acceptVersion, createProjectBudgetRoleRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.createProjectBudgetRole']?.[localVarOperationServerIndex]?.url;
@@ -14283,8 +14618,8 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Delete a person by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
-         * @summary Delete a person
+         * Delete a person or placeholder by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
+         * @summary Delete a person or placeholder
          * @param {boolean} force 
          * @param {number} personId 
          * @param {DeletePersonAcceptVersionEnum} acceptVersion 
@@ -14569,7 +14904,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Show a person
+         * @summary Show a person or placeholder
          * @param {number} personId 
          * @param {GetPersonAcceptVersionEnum} acceptVersion 
          * @param {*} [options] Override http request option.
@@ -14596,13 +14931,14 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
-         * @summary Show current team
+         * This endpoint is deprecated. You may view the current team for a person using the `GET /people/:personId/` endpoint.
+         * @summary Show current team for a person or placeholder
          * @param {number} personId 
          * @param {GetPersonCurrentTeamAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
          * @param {number} [limit] The number of results per page
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         async getPersonCurrentTeam(personId: number, acceptVersion: GetPersonCurrentTeamAcceptVersionEnum, cursor?: string, limit?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetPersonCurrentTeam200Response>> {
@@ -14627,6 +14963,22 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getPersonHoursReport(personId, acceptVersion, cursor, limit, startDate, endDate, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.getPersonHoursReport']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Get a report for a person containing data from the People Overview Report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+         * @summary Show metrics (beta)
+         * @param {number} personId 
+         * @param {GetPersonReportAcceptVersionEnum} acceptVersion 
+         * @param {string} [startDate] The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD
+         * @param {GetPersonReportPeriodTypeEnum} [periodType] The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getPersonReport(personId: number, acceptVersion: GetPersonReportAcceptVersionEnum, startDate?: string, periodType?: GetPersonReportPeriodTypeEnum, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetPersonReport200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getPersonReport(personId, acceptVersion, startDate, periodType, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.getPersonReport']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -14704,6 +15056,22 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getProjectPhase(projectId, phaseId, acceptVersion, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.getProjectPhase']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * Get a report for a project containing data from the Project Overview report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+         * @summary Show metrics (beta)
+         * @param {number} projectId 
+         * @param {GetProjectReportAcceptVersionEnum} acceptVersion 
+         * @param {string} [startDate] The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD
+         * @param {GetProjectReportPeriodTypeEnum} [periodType] The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. If not provided, the report will be for the Overview report (all inclusive).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getProjectReport(projectId: number, acceptVersion: GetProjectReportAcceptVersionEnum, startDate?: string, periodType?: GetProjectReportPeriodTypeEnum, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetProjectReport200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getProjectReport(projectId, acceptVersion, startDate, periodType, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.getProjectReport']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -15165,7 +15533,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {string} [email] If provided, will only return people with an email that are a substring of this value (case-insensitive).
          * @param {string} [firstName] If provided, will only return people with a first name that is a substring of this value (case-insensitive).
          * @param {string} [lastName] If provided, will only return people with a last name that is a substring of this value (case-insensitive).
-         * @param {ModifiedAfter} [modifiedAfter] If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A person is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a person include changing first name, last name, email, references, tags and archiving. A person is not considered modified just because another object it is associated with is changed (e.g. a contract, project or an assignment).
+         * @param {ModifiedAfter} [modifiedAfter] 
          * @param {string} [externalId] External ID value
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15231,7 +15599,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {string} [cursor] Cursor for paginated requests
          * @param {number} [limit] The number of results per page
          * @param {boolean} [includePlaceholders] 
-         * @param {ModifiedAfter} [modifiedAfter] If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ.
+         * @param {ModifiedAfter} [modifiedAfter] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -15280,7 +15648,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary List assignments for a person
+         * @summary List assignments for a person or placeholder
          * @param {number} personId 
          * @param {ListPersonAssignmentsAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -15349,7 +15717,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary List projects for a person
+         * @summary List projects for a person or placeholder
          * @param {number} personId 
          * @param {ListPersonProjectsAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -15397,7 +15765,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary List skills for a person
+         * @summary List skills for a person or placeholder
          * @param {number} personId 
          * @param {ListPersonSkillsAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -15429,7 +15797,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
+         * Note: The /people/_* endpoints also allows getting information on placeholders when using the `includePlaceholders` query parameter.
          * @summary List placeholders
          * @param {ListPlaceholdersAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
@@ -15742,7 +16110,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {number} [limit] The number of results per page
          * @param {ListProjectsSortByEnum} [sortBy] Field to sort by: createdAt or updatedAt or id
          * @param {ListProjectsOrderEnum} [order] Sort order: asc or desc
-         * @param {ModifiedAfter} [modifiedAfter] If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A project is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a project include changing the name, client, status, pricing model, rate type , team, budget, expenses budget, references, and archiving. A project is not considered modified just because another object it is associated with is changed (e.g. actuals, assignments, budget roles, custom fields, milestones, notes, other expenses, people, people requests, phases, rates, timesheet locks &amp; workstreams).
+         * @param {ModifiedAfter} [modifiedAfter] 
          * @param {string} [externalId] External ID value
          * @param {string} [name] Case-insensitive substring match on project name (e.g. &#x60;Acme&#x60;).
          * @param {*} [options] Override http request option.
@@ -15977,14 +16345,15 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * 
-         * @summary Remove a person from a team
+         * This endpoint is deprecated. You may remove the person from a team using the `PATCH /people/:personId/` endpoint.
+         * @summary Remove a person or placeholder from a team
          * @param {number} personId 
          * @param {number} teamId 
          * @param {RemovePersonFromTeamAcceptVersionEnum} acceptVersion 
          * @param {string} [cursor] Cursor for paginated requests
          * @param {number} [limit] The number of results per page
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         async removePersonFromTeam(personId: number, teamId: number, acceptVersion: RemovePersonFromTeamAcceptVersionEnum, cursor?: string, limit?: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
@@ -15995,7 +16364,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Remove a skill from a person
+         * @summary Remove a skill from a person or placeholder
          * @param {number} personId 
          * @param {number} skillId 
          * @param {RemovePersonSkillAcceptVersionEnum} acceptVersion 
@@ -16087,11 +16456,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * Returns Actual with updated minutes. Creates a new actual when there is none to update [Learn more](https://developer.runn.io/docs/actuals-notes).
          * @summary Update an actual
          * @param {UpdateActualTimeEntryAcceptVersionEnum} acceptVersion 
-         * @param {ActualTimeEntry} [actualTimeEntry] 
+         * @param {ActualTimeEntry} actualTimeEntry 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateActualTimeEntry(acceptVersion: UpdateActualTimeEntryAcceptVersionEnum, actualTimeEntry?: ActualTimeEntry, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Actual>> {
+        async updateActualTimeEntry(acceptVersion: UpdateActualTimeEntryAcceptVersionEnum, actualTimeEntry: ActualTimeEntry, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Actual>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateActualTimeEntry(acceptVersion, actualTimeEntry, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateActualTimeEntry']?.[localVarOperationServerIndex]?.url;
@@ -16102,11 +16471,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a checkbox custom field
          * @param {number} checkboxFieldId 
          * @param {UpdateCheckboxCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateCheckboxCustomFieldRequest} [updateCheckboxCustomFieldRequest] 
+         * @param {UpdateCheckboxCustomFieldRequest} updateCheckboxCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateCheckboxCustomField(checkboxFieldId: number, acceptVersion: UpdateCheckboxCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldCheckbox>> {
+        async updateCheckboxCustomField(checkboxFieldId: number, acceptVersion: UpdateCheckboxCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldCheckbox>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateCheckboxCustomField(checkboxFieldId, acceptVersion, updateCheckboxCustomFieldRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateCheckboxCustomField']?.[localVarOperationServerIndex]?.url;
@@ -16117,11 +16486,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a client
          * @param {number} clientId 
          * @param {UpdateClientAcceptVersionEnum} acceptVersion 
-         * @param {UpdateClientRequest} [updateClientRequest] 
+         * @param {UpdateClientRequest} updateClientRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateClient(clientId: number, acceptVersion: UpdateClientAcceptVersionEnum, updateClientRequest?: UpdateClientRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
+        async updateClient(clientId: number, acceptVersion: UpdateClientAcceptVersionEnum, updateClientRequest: UpdateClientRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Client>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateClient(clientId, acceptVersion, updateClientRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateClient']?.[localVarOperationServerIndex]?.url;
@@ -16132,11 +16501,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a contract
          * @param {number} contractId 
          * @param {UpdateContractAcceptVersionEnum} acceptVersion 
-         * @param {UpdateContractRequest} [updateContractRequest] 
+         * @param {UpdateContractRequest} updateContractRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateContract(contractId: number, acceptVersion: UpdateContractAcceptVersionEnum, updateContractRequest?: UpdateContractRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Contract>> {
+        async updateContract(contractId: number, acceptVersion: UpdateContractAcceptVersionEnum, updateContractRequest: UpdateContractRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Contract>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateContract(contractId, acceptVersion, updateContractRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateContract']?.[localVarOperationServerIndex]?.url;
@@ -16147,11 +16516,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a date custom field
          * @param {number} dateFieldId 
          * @param {UpdateDateCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateDateCustomFieldRequest} [updateDateCustomFieldRequest] 
+         * @param {UpdateDateCustomFieldRequest} updateDateCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateDateCustomField(dateFieldId: number, acceptVersion: UpdateDateCustomFieldAcceptVersionEnum, updateDateCustomFieldRequest?: UpdateDateCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldDate>> {
+        async updateDateCustomField(dateFieldId: number, acceptVersion: UpdateDateCustomFieldAcceptVersionEnum, updateDateCustomFieldRequest: UpdateDateCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldDate>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateDateCustomField(dateFieldId, acceptVersion, updateDateCustomFieldRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateDateCustomField']?.[localVarOperationServerIndex]?.url;
@@ -16174,14 +16543,14 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * To add a new role or job title to a person, see POST /people/{personId}/contracts
-         * @summary Update a person
+         * @summary Update a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonAcceptVersionEnum} acceptVersion 
-         * @param {UpdatePersonRequest} [updatePersonRequest] 
+         * @param {UpdatePersonRequest} updatePersonRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updatePerson(personId: number, acceptVersion: UpdatePersonAcceptVersionEnum, updatePersonRequest?: UpdatePersonRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Person>> {
+        async updatePerson(personId: number, acceptVersion: UpdatePersonAcceptVersionEnum, updatePersonRequest: UpdatePersonRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Person>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updatePerson(personId, acceptVersion, updatePersonRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updatePerson']?.[localVarOperationServerIndex]?.url;
@@ -16189,7 +16558,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Add a checkbox custom value to a person
+         * @summary Add a checkbox custom value to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonCheckboxCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonCheckboxCustomFieldRequest} updatePersonCheckboxCustomFieldRequest 
@@ -16204,7 +16573,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Add a date custom value to a person
+         * @summary Add a date custom value to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonDateCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonDateCustomFieldRequest} updatePersonDateCustomFieldRequest 
@@ -16219,7 +16588,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Add custom select options to a person
+         * @summary Add custom select options to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonSelectCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonSelectCustomFieldRequest} updatePersonSelectCustomFieldRequest 
@@ -16234,7 +16603,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Update a skill for a person
+         * @summary Update a skill for a person or placeholder
          * @param {number} personId 
          * @param {number} skillId 
          * @param {UpdatePersonSkillAcceptVersionEnum} acceptVersion 
@@ -16250,7 +16619,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Add a text custom value to a person
+         * @summary Add a text custom value to a person or placeholder
          * @param {number} personId 
          * @param {UpdatePersonTextCustomFieldAcceptVersionEnum} acceptVersion 
          * @param {UpdatePersonTextCustomFieldRequest} updatePersonTextCustomFieldRequest 
@@ -16268,11 +16637,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a project
          * @param {number} projectId 
          * @param {UpdateProjectAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectRequest} [updateProjectRequest] 
+         * @param {UpdateProjectRequest} updateProjectRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateProject(projectId: number, acceptVersion: UpdateProjectAcceptVersionEnum, updateProjectRequest?: UpdateProjectRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Project>> {
+        async updateProject(projectId: number, acceptVersion: UpdateProjectAcceptVersionEnum, updateProjectRequest: UpdateProjectRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Project>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateProject(projectId, acceptVersion, updateProjectRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateProject']?.[localVarOperationServerIndex]?.url;
@@ -16284,11 +16653,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {number} projectId 
          * @param {number} roleId 
          * @param {UpdateProjectBudgetRoleAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectBudgetRoleRequest} [updateProjectBudgetRoleRequest] 
+         * @param {UpdateProjectBudgetRoleRequest} updateProjectBudgetRoleRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateProjectBudgetRole(projectId: number, roleId: number, acceptVersion: UpdateProjectBudgetRoleAcceptVersionEnum, updateProjectBudgetRoleRequest?: UpdateProjectBudgetRoleRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProjectBudgetRole>> {
+        async updateProjectBudgetRole(projectId: number, roleId: number, acceptVersion: UpdateProjectBudgetRoleAcceptVersionEnum, updateProjectBudgetRoleRequest: UpdateProjectBudgetRoleRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProjectBudgetRole>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateProjectBudgetRole(projectId, roleId, acceptVersion, updateProjectBudgetRoleRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateProjectBudgetRole']?.[localVarOperationServerIndex]?.url;
@@ -16330,11 +16699,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {number} projectId 
          * @param {number} milestoneId 
          * @param {UpdateProjectMilestoneAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectMilestoneRequest} [updateProjectMilestoneRequest] 
+         * @param {UpdateProjectMilestoneRequest} updateProjectMilestoneRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateProjectMilestone(projectId: number, milestoneId: number, acceptVersion: UpdateProjectMilestoneAcceptVersionEnum, updateProjectMilestoneRequest?: UpdateProjectMilestoneRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Milestone>> {
+        async updateProjectMilestone(projectId: number, milestoneId: number, acceptVersion: UpdateProjectMilestoneAcceptVersionEnum, updateProjectMilestoneRequest: UpdateProjectMilestoneRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Milestone>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateProjectMilestone(projectId, milestoneId, acceptVersion, updateProjectMilestoneRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateProjectMilestone']?.[localVarOperationServerIndex]?.url;
@@ -16346,11 +16715,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {number} projectId Unique identifier for the project the expense is for.
          * @param {number} otherExpenseId Unique identifier for the other expense to update.
          * @param {UpdateProjectOtherExpenseAcceptVersionEnum} acceptVersion 
-         * @param {ProjectOtherExpense1} [projectOtherExpense1] A non-labour expense for a project.
+         * @param {ProjectOtherExpense1} projectOtherExpense1 A non-labour expense for a project.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateProjectOtherExpense(projectId: number, otherExpenseId: number, acceptVersion: UpdateProjectOtherExpenseAcceptVersionEnum, projectOtherExpense1?: ProjectOtherExpense1, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProjectOtherExpense>> {
+        async updateProjectOtherExpense(projectId: number, otherExpenseId: number, acceptVersion: UpdateProjectOtherExpenseAcceptVersionEnum, projectOtherExpense1: ProjectOtherExpense1, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProjectOtherExpense>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateProjectOtherExpense(projectId, otherExpenseId, acceptVersion, projectOtherExpense1, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateProjectOtherExpense']?.[localVarOperationServerIndex]?.url;
@@ -16378,11 +16747,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {number} projectId 
          * @param {number} phaseId 
          * @param {UpdateProjectPhaseAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectPhaseRequest} [updateProjectPhaseRequest] 
+         * @param {UpdateProjectPhaseRequest} updateProjectPhaseRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateProjectPhase(projectId: number, phaseId: number, acceptVersion: UpdateProjectPhaseAcceptVersionEnum, updateProjectPhaseRequest?: UpdateProjectPhaseRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProjectPhase>> {
+        async updateProjectPhase(projectId: number, phaseId: number, acceptVersion: UpdateProjectPhaseAcceptVersionEnum, updateProjectPhaseRequest: UpdateProjectPhaseRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ProjectPhase>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateProjectPhase(projectId, phaseId, acceptVersion, updateProjectPhaseRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateProjectPhase']?.[localVarOperationServerIndex]?.url;
@@ -16454,11 +16823,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a timesheet lock for a project
          * @param {number} projectId 
          * @param {UpdateProjectTimesheetLockAcceptVersionEnum} acceptVersion 
-         * @param {UpdateProjectTimesheetLockRequest} [updateProjectTimesheetLockRequest] 
+         * @param {UpdateProjectTimesheetLockRequest} updateProjectTimesheetLockRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateProjectTimesheetLock(projectId: number, acceptVersion: UpdateProjectTimesheetLockAcceptVersionEnum, updateProjectTimesheetLockRequest?: UpdateProjectTimesheetLockRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetProjectTimesheetLock200Response>> {
+        async updateProjectTimesheetLock(projectId: number, acceptVersion: UpdateProjectTimesheetLockAcceptVersionEnum, updateProjectTimesheetLockRequest: UpdateProjectTimesheetLockRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetProjectTimesheetLock200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateProjectTimesheetLock(projectId, acceptVersion, updateProjectTimesheetLockRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateProjectTimesheetLock']?.[localVarOperationServerIndex]?.url;
@@ -16466,14 +16835,29 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @summary Update a role
-         * @param {number} roleId 
-         * @param {UpdateRoleAcceptVersionEnum} acceptVersion 
-         * @param {UpdateRoleRequest} [updateRoleRequest] 
+         * @summary Update a rate card
+         * @param {number} rateCardId 
+         * @param {UpdateRateCardAcceptVersionEnum} acceptVersion 
+         * @param {UpdateRateCardRequest} updateRateCardRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateRole(roleId: number, acceptVersion: UpdateRoleAcceptVersionEnum, updateRoleRequest?: UpdateRoleRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Role>> {
+        async updateRateCard(rateCardId: number, acceptVersion: UpdateRateCardAcceptVersionEnum, updateRateCardRequest: UpdateRateCardRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RateCard>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateRateCard(rateCardId, acceptVersion, updateRateCardRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateRateCard']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary Update a role
+         * @param {number} roleId 
+         * @param {UpdateRoleAcceptVersionEnum} acceptVersion 
+         * @param {UpdateRoleRequest} updateRoleRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async updateRole(roleId: number, acceptVersion: UpdateRoleAcceptVersionEnum, updateRoleRequest: UpdateRoleRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Role>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateRole(roleId, acceptVersion, updateRoleRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateRole']?.[localVarOperationServerIndex]?.url;
@@ -16484,11 +16868,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a select custom field
          * @param {number} selectFieldId 
          * @param {UpdateSelectCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateCheckboxCustomFieldRequest} [updateCheckboxCustomFieldRequest] 
+         * @param {UpdateCheckboxCustomFieldRequest} updateCheckboxCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateSelectCustomField(selectFieldId: number, acceptVersion: UpdateSelectCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldSelect>> {
+        async updateSelectCustomField(selectFieldId: number, acceptVersion: UpdateSelectCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldSelect>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateSelectCustomField(selectFieldId, acceptVersion, updateCheckboxCustomFieldRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateSelectCustomField']?.[localVarOperationServerIndex]?.url;
@@ -16545,11 +16929,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a text custom field
          * @param {number} textFieldId 
          * @param {UpdateTextCustomFieldAcceptVersionEnum} acceptVersion 
-         * @param {UpdateCheckboxCustomFieldRequest} [updateCheckboxCustomFieldRequest] 
+         * @param {UpdateCheckboxCustomFieldRequest} updateCheckboxCustomFieldRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateTextCustomField(textFieldId: number, acceptVersion: UpdateTextCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldText>> {
+        async updateTextCustomField(textFieldId: number, acceptVersion: UpdateTextCustomFieldAcceptVersionEnum, updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CustomFieldText>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateTextCustomField(textFieldId, acceptVersion, updateCheckboxCustomFieldRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateTextCustomField']?.[localVarOperationServerIndex]?.url;
@@ -16560,11 +16944,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @summary Update a workstream
          * @param {number} workstreamId 
          * @param {UpdateWorkstreamAcceptVersionEnum} acceptVersion 
-         * @param {UpdateWorkstreamRequest} [updateWorkstreamRequest] 
+         * @param {UpdateWorkstreamRequest} updateWorkstreamRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateWorkstream(workstreamId: number, acceptVersion: UpdateWorkstreamAcceptVersionEnum, updateWorkstreamRequest?: UpdateWorkstreamRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Workstream>> {
+        async updateWorkstream(workstreamId: number, acceptVersion: UpdateWorkstreamAcceptVersionEnum, updateWorkstreamRequest: UpdateWorkstreamRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Workstream>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.updateWorkstream(workstreamId, acceptVersion, updateWorkstreamRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.updateWorkstream']?.[localVarOperationServerIndex]?.url;
@@ -16591,7 +16975,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Add a skill to a person
+         * @summary Add a skill to a person or placeholder
          * @param {DefaultApiAddPersonSkillRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -16601,7 +16985,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Add project to a person
+         * @summary Add project to a person or placeholder
          * @param {DefaultApiAddPersonToProjectRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -16610,10 +16994,11 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.addPersonToProject(requestParameters.personId, requestParameters.acceptVersion, requestParameters.addPersonToProjectRequest, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
-         * @summary Add a person to a team
+         * This endpoint is deprecated. You may assign the person to a team using the `PATCH /people/:personId/` endpoint.
+         * @summary Add a person or placeholder to a team
          * @param {DefaultApiAddPersonToTeamRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         addPersonToTeam(requestParameters: DefaultApiAddPersonToTeamRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
@@ -17080,8 +17465,8 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.deletePeopleTag(requestParameters.peopleTagId, requestParameters.acceptVersion, options).then((request) => request(axios, basePath));
         },
         /**
-         * Delete a person by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
-         * @summary Delete a person
+         * Delete a person or placeholder by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
+         * @summary Delete a person or placeholder
          * @param {DefaultApiDeletePersonRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -17281,7 +17666,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Show a person
+         * @summary Show a person or placeholder
          * @param {DefaultApiGetPersonRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -17300,10 +17685,11 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.getPersonCurrentContract(requestParameters.personId, requestParameters.acceptVersion, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
-         * @summary Show current team
+         * This endpoint is deprecated. You may view the current team for a person using the `GET /people/:personId/` endpoint.
+         * @summary Show current team for a person or placeholder
          * @param {DefaultApiGetPersonCurrentTeamRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         getPersonCurrentTeam(requestParameters: DefaultApiGetPersonCurrentTeamRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetPersonCurrentTeam200Response> {
@@ -17318,6 +17704,16 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         getPersonHoursReport(requestParameters: DefaultApiGetPersonHoursReportRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetPersonHoursReport200Response> {
             return localVarFp.getPersonHoursReport(requestParameters.personId, requestParameters.acceptVersion, requestParameters.cursor, requestParameters.limit, requestParameters.startDate, requestParameters.endDate, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Get a report for a person containing data from the People Overview Report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+         * @summary Show metrics (beta)
+         * @param {DefaultApiGetPersonReportRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getPersonReport(requestParameters: DefaultApiGetPersonReportRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetPersonReport200Response> {
+            return localVarFp.getPersonReport(requestParameters.personId, requestParameters.acceptVersion, requestParameters.startDate, requestParameters.periodType, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -17368,6 +17764,16 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         getProjectPhase(requestParameters: DefaultApiGetProjectPhaseRequest, options?: RawAxiosRequestConfig): AxiosPromise<ProjectPhase> {
             return localVarFp.getProjectPhase(requestParameters.projectId, requestParameters.phaseId, requestParameters.acceptVersion, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Get a report for a project containing data from the Project Overview report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+         * @summary Show metrics (beta)
+         * @param {DefaultApiGetProjectReportRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getProjectReport(requestParameters: DefaultApiGetProjectReportRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetProjectReport200Response> {
+            return localVarFp.getProjectReport(requestParameters.projectId, requestParameters.acceptVersion, requestParameters.startDate, requestParameters.periodType, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -17711,7 +18117,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary List assignments for a person
+         * @summary List assignments for a person or placeholder
          * @param {DefaultApiListPersonAssignmentsRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -17751,7 +18157,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary List projects for a person
+         * @summary List projects for a person or placeholder
          * @param {DefaultApiListPersonProjectsRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -17781,7 +18187,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary List skills for a person
+         * @summary List skills for a person or placeholder
          * @param {DefaultApiListPersonSkillsRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -17800,7 +18206,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.listPhases(requestParameters.acceptVersion, requestParameters.cursor, requestParameters.limit, requestParameters.modifiedAfter, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
+         * Note: The /people/_* endpoints also allows getting information on placeholders when using the `includePlaceholders` query parameter.
          * @summary List placeholders
          * @param {DefaultApiListPlaceholdersRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
@@ -18120,10 +18526,11 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
             return localVarFp.listWorkstreams(requestParameters.acceptVersion, requestParameters.cursor, requestParameters.limit, requestParameters.sortBy, requestParameters.order, requestParameters.modifiedAfter, options).then((request) => request(axios, basePath));
         },
         /**
-         * 
-         * @summary Remove a person from a team
+         * This endpoint is deprecated. You may remove the person from a team using the `PATCH /people/:personId/` endpoint.
+         * @summary Remove a person or placeholder from a team
          * @param {DefaultApiRemovePersonFromTeamRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
+         * @deprecated
          * @throws {RequiredError}
          */
         removePersonFromTeam(requestParameters: DefaultApiRemovePersonFromTeamRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
@@ -18131,7 +18538,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Remove a skill from a person
+         * @summary Remove a skill from a person or placeholder
          * @param {DefaultApiRemovePersonSkillRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -18251,7 +18658,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * To add a new role or job title to a person, see POST /people/{personId}/contracts
-         * @summary Update a person
+         * @summary Update a person or placeholder
          * @param {DefaultApiUpdatePersonRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -18261,7 +18668,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Add a checkbox custom value to a person
+         * @summary Add a checkbox custom value to a person or placeholder
          * @param {DefaultApiUpdatePersonCheckboxCustomFieldRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -18271,7 +18678,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Add a date custom value to a person
+         * @summary Add a date custom value to a person or placeholder
          * @param {DefaultApiUpdatePersonDateCustomFieldRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -18281,7 +18688,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Add custom select options to a person
+         * @summary Add custom select options to a person or placeholder
          * @param {DefaultApiUpdatePersonSelectCustomFieldRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -18291,7 +18698,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Update a skill for a person
+         * @summary Update a skill for a person or placeholder
          * @param {DefaultApiUpdatePersonSkillRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -18301,7 +18708,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @summary Add a text custom value to a person
+         * @summary Add a text custom value to a person or placeholder
          * @param {DefaultApiUpdatePersonTextCustomFieldRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -18438,6 +18845,16 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         updateProjectTimesheetLock(requestParameters: DefaultApiUpdateProjectTimesheetLockRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetProjectTimesheetLock200Response> {
             return localVarFp.updateProjectTimesheetLock(requestParameters.projectId, requestParameters.acceptVersion, requestParameters.updateProjectTimesheetLockRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Update a rate card
+         * @param {DefaultApiUpdateRateCardRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateRateCard(requestParameters: DefaultApiUpdateRateCardRequest, options?: RawAxiosRequestConfig): AxiosPromise<RateCard> {
+            return localVarFp.updateRateCard(requestParameters.rateCardId, requestParameters.acceptVersion, requestParameters.updateRateCardRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -18634,7 +19051,7 @@ export interface DefaultApiConvertLegacyIdRequest {
 export interface DefaultApiCreateActualRequest {
     readonly acceptVersion: CreateActualAcceptVersionEnum
 
-    readonly actualInput?: ActualInput
+    readonly actualInput: ActualInput
 }
 
 /**
@@ -18670,7 +19087,7 @@ export interface DefaultApiCreateCheckboxCustomFieldRequest {
 export interface DefaultApiCreateClientRequest {
     readonly acceptVersion: CreateClientAcceptVersionEnum
 
-    readonly clientInput?: ClientInput
+    readonly clientInput: ClientInput
 }
 
 /**
@@ -18697,7 +19114,7 @@ export interface DefaultApiCreateDateCustomFieldRequest {
 export interface DefaultApiCreateHolidayTimeOffRequest {
     readonly acceptVersion: CreateHolidayTimeOffAcceptVersionEnum
 
-    readonly timeOffHolidayInput?: TimeOffHolidayInput
+    readonly timeOffHolidayInput: TimeOffHolidayInput
 }
 
 /**
@@ -18706,7 +19123,7 @@ export interface DefaultApiCreateHolidayTimeOffRequest {
 export interface DefaultApiCreateInvitationRequest {
     readonly acceptVersion: CreateInvitationAcceptVersionEnum
 
-    readonly createInvitationRequest?: CreateInvitationRequest
+    readonly createInvitationRequest: CreateInvitationRequest
 }
 
 /**
@@ -18715,7 +19132,7 @@ export interface DefaultApiCreateInvitationRequest {
 export interface DefaultApiCreateLeaveTimeOffRequest {
     readonly acceptVersion: CreateLeaveTimeOffAcceptVersionEnum
 
-    readonly timeOffLeaveInput?: TimeOffLeaveInput
+    readonly timeOffLeaveInput: TimeOffLeaveInput
 }
 
 /**
@@ -18764,7 +19181,7 @@ export interface DefaultApiCreatePersonContractRequest {
 
     readonly acceptVersion: CreatePersonContractAcceptVersionEnum
 
-    readonly contractInput?: ContractInput
+    readonly contractInput: ContractInput
 }
 
 /**
@@ -18782,7 +19199,7 @@ export interface DefaultApiCreatePlaceholderRequest {
 export interface DefaultApiCreateProjectRequest {
     readonly acceptVersion: CreateProjectAcceptVersionEnum
 
-    readonly createProjectRequest?: CreateProjectRequest
+    readonly createProjectRequest: CreateProjectRequest
 }
 
 /**
@@ -18793,7 +19210,7 @@ export interface DefaultApiCreateProjectBudgetRoleRequest {
 
     readonly acceptVersion: CreateProjectBudgetRoleAcceptVersionEnum
 
-    readonly createProjectBudgetRoleRequest?: CreateProjectBudgetRoleRequest
+    readonly createProjectBudgetRoleRequest: CreateProjectBudgetRoleRequest
 }
 
 /**
@@ -19282,6 +19699,25 @@ export interface DefaultApiGetPersonHoursReportRequest {
 }
 
 /**
+ * Request parameters for getPersonReport operation in DefaultApi.
+ */
+export interface DefaultApiGetPersonReportRequest {
+    readonly personId: number
+
+    readonly acceptVersion: GetPersonReportAcceptVersionEnum
+
+    /**
+     * The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD
+     */
+    readonly startDate?: string
+
+    /**
+     * The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September.
+     */
+    readonly periodType?: GetPersonReportPeriodTypeEnum
+}
+
+/**
  * Request parameters for getProject operation in DefaultApi.
  */
 export interface DefaultApiGetProjectRequest {
@@ -19350,6 +19786,25 @@ export interface DefaultApiGetProjectPhaseRequest {
     readonly phaseId: number
 
     readonly acceptVersion: GetProjectPhaseAcceptVersionEnum
+}
+
+/**
+ * Request parameters for getProjectReport operation in DefaultApi.
+ */
+export interface DefaultApiGetProjectReportRequest {
+    readonly projectId: number
+
+    readonly acceptVersion: GetProjectReportAcceptVersionEnum
+
+    /**
+     * The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD
+     */
+    readonly startDate?: string
+
+    /**
+     * The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. If not provided, the report will be for the Overview report (all inclusive).
+     */
+    readonly periodType?: GetProjectReportPeriodTypeEnum
 }
 
 /**
@@ -19941,9 +20396,6 @@ export interface DefaultApiListPeopleRequest {
      */
     readonly lastName?: string
 
-    /**
-     * If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A person is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a person include changing first name, last name, email, references, tags and archiving. A person is not considered modified just because another object it is associated with is changed (e.g. a contract, project or an assignment).
-     */
     readonly modifiedAfter?: ModifiedAfter
 
     /**
@@ -20027,9 +20479,6 @@ export interface DefaultApiListPeopleSkillsRequest {
 
     readonly includePlaceholders?: boolean
 
-    /**
-     * If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ.
-     */
     readonly modifiedAfter?: ModifiedAfter
 }
 
@@ -20707,9 +21156,6 @@ export interface DefaultApiListProjectsRequest {
      */
     readonly order?: ListProjectsOrderEnum
 
-    /**
-     * If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A project is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a project include changing the name, client, status, pricing model, rate type , team, budget, expenses budget, references, and archiving. A project is not considered modified just because another object it is associated with is changed (e.g. actuals, assignments, budget roles, custom fields, milestones, notes, other expenses, people, people requests, phases, rates, timesheet locks &amp; workstreams).
-     */
     readonly modifiedAfter?: ModifiedAfter
 
     /**
@@ -21124,7 +21570,7 @@ export interface DefaultApiRemoveWorkstreamFromProjectRequest {
 export interface DefaultApiUpdateActualTimeEntryRequest {
     readonly acceptVersion: UpdateActualTimeEntryAcceptVersionEnum
 
-    readonly actualTimeEntry?: ActualTimeEntry
+    readonly actualTimeEntry: ActualTimeEntry
 }
 
 /**
@@ -21135,7 +21581,7 @@ export interface DefaultApiUpdateCheckboxCustomFieldRequest {
 
     readonly acceptVersion: UpdateCheckboxCustomFieldAcceptVersionEnum
 
-    readonly updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest
+    readonly updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest
 }
 
 /**
@@ -21146,7 +21592,7 @@ export interface DefaultApiUpdateClientRequest {
 
     readonly acceptVersion: UpdateClientAcceptVersionEnum
 
-    readonly updateClientRequest?: UpdateClientRequest
+    readonly updateClientRequest: UpdateClientRequest
 }
 
 /**
@@ -21157,7 +21603,7 @@ export interface DefaultApiUpdateContractRequest {
 
     readonly acceptVersion: UpdateContractAcceptVersionEnum
 
-    readonly updateContractRequest?: UpdateContractRequest
+    readonly updateContractRequest: UpdateContractRequest
 }
 
 /**
@@ -21168,7 +21614,7 @@ export interface DefaultApiUpdateDateCustomFieldRequest {
 
     readonly acceptVersion: UpdateDateCustomFieldAcceptVersionEnum
 
-    readonly updateDateCustomFieldRequest?: UpdateDateCustomFieldRequest
+    readonly updateDateCustomFieldRequest: UpdateDateCustomFieldRequest
 }
 
 /**
@@ -21190,7 +21636,7 @@ export interface DefaultApiUpdatePersonRequest {
 
     readonly acceptVersion: UpdatePersonAcceptVersionEnum
 
-    readonly updatePersonRequest?: UpdatePersonRequest
+    readonly updatePersonRequest: UpdatePersonRequest
 }
 
 /**
@@ -21258,7 +21704,7 @@ export interface DefaultApiUpdateProjectRequest {
 
     readonly acceptVersion: UpdateProjectAcceptVersionEnum
 
-    readonly updateProjectRequest?: UpdateProjectRequest
+    readonly updateProjectRequest: UpdateProjectRequest
 }
 
 /**
@@ -21271,7 +21717,7 @@ export interface DefaultApiUpdateProjectBudgetRoleRequest {
 
     readonly acceptVersion: UpdateProjectBudgetRoleAcceptVersionEnum
 
-    readonly updateProjectBudgetRoleRequest?: UpdateProjectBudgetRoleRequest
+    readonly updateProjectBudgetRoleRequest: UpdateProjectBudgetRoleRequest
 }
 
 /**
@@ -21306,7 +21752,7 @@ export interface DefaultApiUpdateProjectMilestoneRequest {
 
     readonly acceptVersion: UpdateProjectMilestoneAcceptVersionEnum
 
-    readonly updateProjectMilestoneRequest?: UpdateProjectMilestoneRequest
+    readonly updateProjectMilestoneRequest: UpdateProjectMilestoneRequest
 }
 
 /**
@@ -21328,7 +21774,7 @@ export interface DefaultApiUpdateProjectOtherExpenseRequest {
     /**
      * A non-labour expense for a project.
      */
-    readonly projectOtherExpense1?: ProjectOtherExpense1
+    readonly projectOtherExpense1: ProjectOtherExpense1
 }
 
 /**
@@ -21354,7 +21800,7 @@ export interface DefaultApiUpdateProjectPhaseRequest {
 
     readonly acceptVersion: UpdateProjectPhaseAcceptVersionEnum
 
-    readonly updateProjectPhaseRequest?: UpdateProjectPhaseRequest
+    readonly updateProjectPhaseRequest: UpdateProjectPhaseRequest
 }
 
 /**
@@ -21411,7 +21857,18 @@ export interface DefaultApiUpdateProjectTimesheetLockRequest {
 
     readonly acceptVersion: UpdateProjectTimesheetLockAcceptVersionEnum
 
-    readonly updateProjectTimesheetLockRequest?: UpdateProjectTimesheetLockRequest
+    readonly updateProjectTimesheetLockRequest: UpdateProjectTimesheetLockRequest
+}
+
+/**
+ * Request parameters for updateRateCard operation in DefaultApi.
+ */
+export interface DefaultApiUpdateRateCardRequest {
+    readonly rateCardId: number
+
+    readonly acceptVersion: UpdateRateCardAcceptVersionEnum
+
+    readonly updateRateCardRequest: UpdateRateCardRequest
 }
 
 /**
@@ -21422,7 +21879,7 @@ export interface DefaultApiUpdateRoleRequest {
 
     readonly acceptVersion: UpdateRoleAcceptVersionEnum
 
-    readonly updateRoleRequest?: UpdateRoleRequest
+    readonly updateRoleRequest: UpdateRoleRequest
 }
 
 /**
@@ -21433,7 +21890,7 @@ export interface DefaultApiUpdateSelectCustomFieldRequest {
 
     readonly acceptVersion: UpdateSelectCustomFieldAcceptVersionEnum
 
-    readonly updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest
+    readonly updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest
 }
 
 /**
@@ -21479,7 +21936,7 @@ export interface DefaultApiUpdateTextCustomFieldRequest {
 
     readonly acceptVersion: UpdateTextCustomFieldAcceptVersionEnum
 
-    readonly updateCheckboxCustomFieldRequest?: UpdateCheckboxCustomFieldRequest
+    readonly updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest
 }
 
 /**
@@ -21490,7 +21947,7 @@ export interface DefaultApiUpdateWorkstreamRequest {
 
     readonly acceptVersion: UpdateWorkstreamAcceptVersionEnum
 
-    readonly updateWorkstreamRequest?: UpdateWorkstreamRequest
+    readonly updateWorkstreamRequest: UpdateWorkstreamRequest
 }
 
 /**
@@ -21510,7 +21967,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Add a skill to a person
+     * @summary Add a skill to a person or placeholder
      * @param {DefaultApiAddPersonSkillRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -21521,7 +21978,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Add project to a person
+     * @summary Add project to a person or placeholder
      * @param {DefaultApiAddPersonToProjectRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -21531,10 +21988,11 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
-     * 
-     * @summary Add a person to a team
+     * This endpoint is deprecated. You may assign the person to a team using the `PATCH /people/:personId/` endpoint.
+     * @summary Add a person or placeholder to a team
      * @param {DefaultApiAddPersonToTeamRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     public addPersonToTeam(requestParameters: DefaultApiAddPersonToTeamRequest, options?: RawAxiosRequestConfig) {
@@ -22048,8 +22506,8 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
-     * Delete a person by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
-     * @summary Delete a person
+     * Delete a person or placeholder by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
+     * @summary Delete a person or placeholder
      * @param {DefaultApiDeletePersonRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -22269,7 +22727,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Show a person
+     * @summary Show a person or placeholder
      * @param {DefaultApiGetPersonRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -22290,10 +22748,11 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
-     * 
-     * @summary Show current team
+     * This endpoint is deprecated. You may view the current team for a person using the `GET /people/:personId/` endpoint.
+     * @summary Show current team for a person or placeholder
      * @param {DefaultApiGetPersonCurrentTeamRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     public getPersonCurrentTeam(requestParameters: DefaultApiGetPersonCurrentTeamRequest, options?: RawAxiosRequestConfig) {
@@ -22309,6 +22768,17 @@ export class DefaultApi extends BaseAPI {
      */
     public getPersonHoursReport(requestParameters: DefaultApiGetPersonHoursReportRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).getPersonHoursReport(requestParameters.personId, requestParameters.acceptVersion, requestParameters.cursor, requestParameters.limit, requestParameters.startDate, requestParameters.endDate, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get a report for a person containing data from the People Overview Report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+     * @summary Show metrics (beta)
+     * @param {DefaultApiGetPersonReportRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public getPersonReport(requestParameters: DefaultApiGetPersonReportRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).getPersonReport(requestParameters.personId, requestParameters.acceptVersion, requestParameters.startDate, requestParameters.periodType, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -22364,6 +22834,17 @@ export class DefaultApi extends BaseAPI {
      */
     public getProjectPhase(requestParameters: DefaultApiGetProjectPhaseRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).getProjectPhase(requestParameters.projectId, requestParameters.phaseId, requestParameters.acceptVersion, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Get a report for a project containing data from the Project Overview report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+     * @summary Show metrics (beta)
+     * @param {DefaultApiGetProjectReportRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public getProjectReport(requestParameters: DefaultApiGetProjectReportRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).getProjectReport(requestParameters.projectId, requestParameters.acceptVersion, requestParameters.startDate, requestParameters.periodType, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -22742,7 +23223,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary List assignments for a person
+     * @summary List assignments for a person or placeholder
      * @param {DefaultApiListPersonAssignmentsRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -22786,7 +23267,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary List projects for a person
+     * @summary List projects for a person or placeholder
      * @param {DefaultApiListPersonProjectsRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -22819,7 +23300,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary List skills for a person
+     * @summary List skills for a person or placeholder
      * @param {DefaultApiListPersonSkillsRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -22840,7 +23321,7 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
-     * 
+     * Note: The /people/_* endpoints also allows getting information on placeholders when using the `includePlaceholders` query parameter.
      * @summary List placeholders
      * @param {DefaultApiListPlaceholdersRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -23192,10 +23673,11 @@ export class DefaultApi extends BaseAPI {
     }
 
     /**
-     * 
-     * @summary Remove a person from a team
+     * This endpoint is deprecated. You may remove the person from a team using the `PATCH /people/:personId/` endpoint.
+     * @summary Remove a person or placeholder from a team
      * @param {DefaultApiRemovePersonFromTeamRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
+     * @deprecated
      * @throws {RequiredError}
      */
     public removePersonFromTeam(requestParameters: DefaultApiRemovePersonFromTeamRequest, options?: RawAxiosRequestConfig) {
@@ -23204,7 +23686,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Remove a skill from a person
+     * @summary Remove a skill from a person or placeholder
      * @param {DefaultApiRemovePersonSkillRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -23336,7 +23818,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * To add a new role or job title to a person, see POST /people/{personId}/contracts
-     * @summary Update a person
+     * @summary Update a person or placeholder
      * @param {DefaultApiUpdatePersonRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -23347,7 +23829,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Add a checkbox custom value to a person
+     * @summary Add a checkbox custom value to a person or placeholder
      * @param {DefaultApiUpdatePersonCheckboxCustomFieldRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -23358,7 +23840,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Add a date custom value to a person
+     * @summary Add a date custom value to a person or placeholder
      * @param {DefaultApiUpdatePersonDateCustomFieldRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -23369,7 +23851,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Add custom select options to a person
+     * @summary Add custom select options to a person or placeholder
      * @param {DefaultApiUpdatePersonSelectCustomFieldRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -23380,7 +23862,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Update a skill for a person
+     * @summary Update a skill for a person or placeholder
      * @param {DefaultApiUpdatePersonSkillRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -23391,7 +23873,7 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @summary Add a text custom value to a person
+     * @summary Add a text custom value to a person or placeholder
      * @param {DefaultApiUpdatePersonTextCustomFieldRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -23541,6 +24023,17 @@ export class DefaultApi extends BaseAPI {
      */
     public updateProjectTimesheetLock(requestParameters: DefaultApiUpdateProjectTimesheetLockRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).updateProjectTimesheetLock(requestParameters.projectId, requestParameters.acceptVersion, requestParameters.updateProjectTimesheetLockRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Update a rate card
+     * @param {DefaultApiUpdateRateCardRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public updateRateCard(requestParameters: DefaultApiUpdateRateCardRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).updateRateCard(requestParameters.rateCardId, requestParameters.acceptVersion, requestParameters.updateRateCardRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -23946,6 +24439,16 @@ export const GetPersonHoursReportAcceptVersionEnum = {
     _100: '1.0.0'
 } as const;
 export type GetPersonHoursReportAcceptVersionEnum = typeof GetPersonHoursReportAcceptVersionEnum[keyof typeof GetPersonHoursReportAcceptVersionEnum];
+export const GetPersonReportAcceptVersionEnum = {
+    _100: '1.0.0'
+} as const;
+export type GetPersonReportAcceptVersionEnum = typeof GetPersonReportAcceptVersionEnum[keyof typeof GetPersonReportAcceptVersionEnum];
+export const GetPersonReportPeriodTypeEnum = {
+    Monthly: 'monthly',
+    Weekly: 'weekly',
+    Quarterly: 'quarterly'
+} as const;
+export type GetPersonReportPeriodTypeEnum = typeof GetPersonReportPeriodTypeEnum[keyof typeof GetPersonReportPeriodTypeEnum];
 export const GetProjectAcceptVersionEnum = {
     _100: '1.0.0'
 } as const;
@@ -23966,6 +24469,16 @@ export const GetProjectPhaseAcceptVersionEnum = {
     _100: '1.0.0'
 } as const;
 export type GetProjectPhaseAcceptVersionEnum = typeof GetProjectPhaseAcceptVersionEnum[keyof typeof GetProjectPhaseAcceptVersionEnum];
+export const GetProjectReportAcceptVersionEnum = {
+    _100: '1.0.0'
+} as const;
+export type GetProjectReportAcceptVersionEnum = typeof GetProjectReportAcceptVersionEnum[keyof typeof GetProjectReportAcceptVersionEnum];
+export const GetProjectReportPeriodTypeEnum = {
+    Monthly: 'monthly',
+    Weekly: 'weekly',
+    Quarterly: 'quarterly'
+} as const;
+export type GetProjectReportPeriodTypeEnum = typeof GetProjectReportPeriodTypeEnum[keyof typeof GetProjectReportPeriodTypeEnum];
 export const GetProjectTagAcceptVersionEnum = {
     _100: '1.0.0'
 } as const;
@@ -24607,6 +25120,10 @@ export const UpdateProjectTimesheetLockAcceptVersionEnum = {
     _100: '1.0.0'
 } as const;
 export type UpdateProjectTimesheetLockAcceptVersionEnum = typeof UpdateProjectTimesheetLockAcceptVersionEnum[keyof typeof UpdateProjectTimesheetLockAcceptVersionEnum];
+export const UpdateRateCardAcceptVersionEnum = {
+    _100: '1.0.0'
+} as const;
+export type UpdateRateCardAcceptVersionEnum = typeof UpdateRateCardAcceptVersionEnum[keyof typeof UpdateRateCardAcceptVersionEnum];
 export const UpdateRoleAcceptVersionEnum = {
     _100: '1.0.0'
 } as const;

--- a/docs/CreateActualsBulk400Response.md
+++ b/docs/CreateActualsBulk400Response.md
@@ -1,0 +1,24 @@
+# CreateActualsBulk400Response
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**error** | **string** |  | [default to undefined]
+**message** | **string** |  | [default to undefined]
+**statusCode** | **number** |  | [default to undefined]
+
+## Example
+
+```typescript
+import { CreateActualsBulk400Response } from 'runn-typescript-sdk';
+
+const instance: CreateActualsBulk400Response = {
+    error,
+    message,
+    statusCode,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/CreateInvitationRequest.md
+++ b/docs/CreateInvitationRequest.md
@@ -10,9 +10,9 @@ Name | Type | Description | Notes
 **financialPermission** | **string** | Financial permission level | [default to undefined]
 **fromUser** | **string** | Email address of user the invite should be sent from (must be a Runn user with admin permissions). | [default to undefined]
 **editProjectsPermission** | **string** | Permissions for editing projects. (deprecated: use manageProjectsPermission) | [default to undefined]
-**editOthersPermission** | **string** | Permissions for editing other parts of the account (people, clients, teams etc.) | [default to undefined]
+**editOthersPermission** | **string** | Permissions for editing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission) | [default to undefined]
 **manageProjectsPermission** | **string** | Permissions for managing projects. | [default to undefined]
-**manageOthersPermission** | **string** | Permissions for managing other parts of the account (people, clients, teams etc.) | [default to undefined]
+**manageOthersPermission** | **string** | Permissions for managing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission) | [default to undefined]
 
 ## Example
 

--- a/docs/CreateInvitationRequestAllOfAnyOf.md
+++ b/docs/CreateInvitationRequestAllOfAnyOf.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **editProjectsPermission** | **string** | Permissions for editing projects. (deprecated: use manageProjectsPermission) | [default to undefined]
-**editOthersPermission** | **string** | Permissions for editing other parts of the account (people, clients, teams etc.) | [default to undefined]
+**editOthersPermission** | **string** | Permissions for editing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission) | [default to undefined]
 
 ## Example
 

--- a/docs/CreateInvitationRequestAllOfAnyOf1.md
+++ b/docs/CreateInvitationRequestAllOfAnyOf1.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **manageProjectsPermission** | **string** | Permissions for managing projects. | [default to undefined]
-**manageOthersPermission** | **string** | Permissions for managing other parts of the account (people, clients, teams etc.) | [default to undefined]
+**manageOthersPermission** | **string** | Permissions for managing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission) | [default to undefined]
 
 ## Example
 

--- a/docs/CreatePersonRequest.md
+++ b/docs/CreatePersonRequest.md
@@ -8,9 +8,11 @@ Name | Type | Description | Notes
 **firstName** | **string** |  | [default to undefined]
 **lastName** | **string** |  | [default to undefined]
 **email** | **string** |  | [optional] [default to undefined]
+**teamId** | **number** |  | [optional] [default to undefined]
 **holidaysGroupId** | **number** |  | [optional] [default to undefined]
 **tags** | [**Array&lt;UpdatePersonRequestTagsInner&gt;**](UpdatePersonRequestTagsInner.md) |  | [optional] [default to undefined]
 **references** | [**Array&lt;Reference&gt;**](Reference.md) |  | [optional] [default to undefined]
+**managers** | [**Array&lt;UpdatePersonRequestManagersInner&gt;**](UpdatePersonRequestManagersInner.md) |  | [optional] [default to undefined]
 **roleId** | **number** |  | [default to undefined]
 **startDate** | **string** | Defaults to today. Format: YYYY-MM-DD | [optional] [default to undefined]
 **endDate** | **string** | Format: YYYY-MM-DD | [optional] [default to undefined]
@@ -29,9 +31,11 @@ const instance: CreatePersonRequest = {
     firstName,
     lastName,
     email,
+    teamId,
     holidaysGroupId,
     tags,
     references,
+    managers,
     roleId,
     startDate,
     endDate,

--- a/docs/CreatePlaceholderRequest.md
+++ b/docs/CreatePlaceholderRequest.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **roleId** | **number** |  | [default to undefined]
 **costPerHour** | **number** | Defaults to the role\&#39;s cost per hour | [optional] [default to undefined]
+**teamId** | **number** |  | [optional] [default to undefined]
 **tags** | [**Array&lt;UpdatePersonRequestTagsInner&gt;**](UpdatePersonRequestTagsInner.md) |  | [optional] [default to undefined]
 
 ## Example
@@ -17,6 +18,7 @@ import { CreatePlaceholderRequest } from 'runn-typescript-sdk';
 const instance: CreatePlaceholderRequest = {
     roleId,
     costPerHour,
+    teamId,
     tags,
 };
 ```

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -5,9 +5,9 @@ All URIs are relative to *https://api.runn.io*
 |Method | HTTP request | Description|
 |------------- | ------------- | -------------|
 |[**addPeopleToSkill**](#addpeopletoskill) | **POST** /skills/{skillId}/people/ | Add people to a skill|
-|[**addPersonSkill**](#addpersonskill) | **POST** /people/{personId}/skills/ | Add a skill to a person|
-|[**addPersonToProject**](#addpersontoproject) | **POST** /people/{personId}/projects/ | Add project to a person|
-|[**addPersonToTeam**](#addpersontoteam) | **POST** /people/{personId}/teams/ | Add a person to a team|
+|[**addPersonSkill**](#addpersonskill) | **POST** /people/{personId}/skills/ | Add a skill to a person or placeholder|
+|[**addPersonToProject**](#addpersontoproject) | **POST** /people/{personId}/projects/ | Add project to a person or placeholder|
+|[**addPersonToTeam**](#addpersontoteam) | **POST** /people/{personId}/teams/ | Add a person or placeholder to a team|
 |[**addPlaceholderSkill**](#addplaceholderskill) | **POST** /placeholders/{placeholderId}/skills/ | Add a skill to a placeholder|
 |[**addPlaceholderToTeam**](#addplaceholdertoteam) | **POST** /placeholders/{placeholderId}/teams/ | Add a placeholder to a team|
 |[**addProjectTagToProject**](#addprojecttagtoproject) | **POST** /project-tags/{projectTagId}/project/{projectId} | Add a project tag to a project|
@@ -54,7 +54,7 @@ All URIs are relative to *https://api.runn.io*
 |[**deleteLeaveTimeOff**](#deleteleavetimeoff) | **DELETE** /time-offs/leave/{timeOffId}/ | Delete a leave time off|
 |[**deleteLeaveTimeOffsBulk**](#deleteleavetimeoffsbulk) | **DELETE** /time-offs/leave/bulk/ | Delete leave time offs in bulk|
 |[**deletePeopleTag**](#deletepeopletag) | **DELETE** /people-tags/{peopleTagId} | Delete a people tag|
-|[**deletePerson**](#deleteperson) | **DELETE** /people/{personId} | Delete a person|
+|[**deletePerson**](#deleteperson) | **DELETE** /people/{personId} | Delete a person or placeholder|
 |[**deletePersonContract**](#deletepersoncontract) | **DELETE** /people/{personId}/contracts/{contractId} | Delete a contract for a person|
 |[**deleteProject**](#deleteproject) | **DELETE** /projects/{projectId}/ | Delete a project|
 |[**deleteProjectBudgetRole**](#deleteprojectbudgetrole) | **DELETE** /projects/{projectId}/budget-roles/{roleId} | Delete a project budget role|
@@ -74,15 +74,17 @@ All URIs are relative to *https://api.runn.io*
 |[**getHolidayGroup**](#getholidaygroup) | **GET** /holiday-groups/{holidayGroupId} | Show a holiday group|
 |[**getLeaveTimeOff**](#getleavetimeoff) | **GET** /time-offs/leave/{timeOffId}/ | Show a leave time off|
 |[**getPeopleTag**](#getpeopletag) | **GET** /people-tags/{peopleTagId} | Show a people tag|
-|[**getPerson**](#getperson) | **GET** /people/{personId} | Show a person|
+|[**getPerson**](#getperson) | **GET** /people/{personId} | Show a person or placeholder|
 |[**getPersonCurrentContract**](#getpersoncurrentcontract) | **GET** /people/{personId}/contracts/current | Show current contract for a person|
-|[**getPersonCurrentTeam**](#getpersoncurrentteam) | **GET** /people/{personId}/teams/current | Show current team|
+|[**getPersonCurrentTeam**](#getpersoncurrentteam) | **GET** /people/{personId}/teams/current | Show current team for a person or placeholder|
 |[**getPersonHoursReport**](#getpersonhoursreport) | **GET** /reports/hours/people/{personId} | Get by-day entries for a person with assignments and actuals|
+|[**getPersonReport**](#getpersonreport) | **GET** /reports/people/{personId}/ | Show metrics (beta)|
 |[**getProject**](#getproject) | **GET** /projects/{projectId} | Show a project|
 |[**getProjectBudgetRole**](#getprojectbudgetrole) | **GET** /projects/{projectId}/budget-roles/{roleId} | Get a project budget role|
 |[**getProjectHoursReport**](#getprojecthoursreport) | **GET** /reports/hours/projects/{projectId} | Get by-day entries for a project with assignments and actuals|
 |[**getProjectPersonRequest**](#getprojectpersonrequest) | **GET** /projects/{projectId}/person-requests/{personRequestId} | Show a single person request for a project|
 |[**getProjectPhase**](#getprojectphase) | **GET** /projects/{projectId}/phases/{phaseId} | Show a phase for a project|
+|[**getProjectReport**](#getprojectreport) | **GET** /reports/projects/{projectId}/ | Show metrics (beta)|
 |[**getProjectTag**](#getprojecttag) | **GET** /project-tags/{projectTagId} | Show a project tag|
 |[**getProjectTimesheetLock**](#getprojecttimesheetlock) | **GET** /projects/{projectId}/timesheet-lock/ | Show a timesheet lock for a project|
 |[**getProjectTotalsReport**](#getprojecttotalsreport) | **GET** /reports/totals/projects/{projectId} | Show totals for a project with assignments and actuals|
@@ -117,14 +119,14 @@ All URIs are relative to *https://api.runn.io*
 |[**listPeopleSkills**](#listpeopleskills) | **GET** /people/skills | List people skills|
 |[**listPeopleTags**](#listpeopletags) | **GET** /people-tags/ | List people tags|
 |[**listPersonActuals**](#listpersonactuals) | **GET** /people/{personId}/actuals/ | List actuals for a person|
-|[**listPersonAssignments**](#listpersonassignments) | **GET** /people/{personId}/assignments/ | List assignments for a person|
+|[**listPersonAssignments**](#listpersonassignments) | **GET** /people/{personId}/assignments/ | List assignments for a person or placeholder|
 |[**listPersonContracts**](#listpersoncontracts) | **GET** /people/{personId}/contracts/ | List contracts for a person|
 |[**listPersonHolidays**](#listpersonholidays) | **GET** /people/{personId}/time-offs/holidays | List holidays for a person|
 |[**listPersonLeave**](#listpersonleave) | **GET** /people/{personId}/time-offs/leave | List leave for a person|
-|[**listPersonProjects**](#listpersonprojects) | **GET** /people/{personId}/projects/ | List projects for a person|
+|[**listPersonProjects**](#listpersonprojects) | **GET** /people/{personId}/projects/ | List projects for a person or placeholder|
 |[**listPersonRequests**](#listpersonrequests) | **GET** /person-requests/ | List person requests|
 |[**listPersonRosteredTimeOffs**](#listpersonrosteredtimeoffs) | **GET** /people/{personId}/time-offs/rostered-off | List rostered time offs for a person|
-|[**listPersonSkills**](#listpersonskills) | **GET** /people/{personId}/skills/ | List skills for a person|
+|[**listPersonSkills**](#listpersonskills) | **GET** /people/{personId}/skills/ | List skills for a person or placeholder|
 |[**listPhases**](#listphases) | **GET** /phases/ | List phases|
 |[**listPlaceholders**](#listplaceholders) | **GET** /placeholders/ | List placeholders|
 |[**listProjectActuals**](#listprojectactuals) | **GET** /projects/{projectId}/actuals/ | List actuals for a project|
@@ -158,8 +160,8 @@ All URIs are relative to *https://api.runn.io*
 |[**listUsers**](#listusers) | **GET** /users/ | List users|
 |[**listViews**](#listviews) | **GET** /views/ | List views|
 |[**listWorkstreams**](#listworkstreams) | **GET** /workstreams/ | List workstreams|
-|[**removePersonFromTeam**](#removepersonfromteam) | **DELETE** /people/{personId}/teams/{teamId} | Remove a person from a team|
-|[**removePersonSkill**](#removepersonskill) | **DELETE** /people/{personId}/skills/{skillId} | Remove a skill from a person|
+|[**removePersonFromTeam**](#removepersonfromteam) | **DELETE** /people/{personId}/teams/{teamId} | Remove a person or placeholder from a team|
+|[**removePersonSkill**](#removepersonskill) | **DELETE** /people/{personId}/skills/{skillId} | Remove a skill from a person or placeholder|
 |[**removePlaceholderFromTeam**](#removeplaceholderfromteam) | **DELETE** /placeholders/{placeholderId}/teams/{teamId} | Remove a placeholder from a team|
 |[**removePlaceholderSkill**](#removeplaceholderskill) | **DELETE** /placeholders/{placeholderId}/skills/{skillId} | Remove a skill from a placeholder|
 |[**removeProjectTagFromProject**](#removeprojecttagfromproject) | **DELETE** /project-tags/{projectTagId}/project/{projectId} | Remove a project tag from a project|
@@ -171,12 +173,12 @@ All URIs are relative to *https://api.runn.io*
 |[**updateContract**](#updatecontract) | **PATCH** /contracts/{contractId} | Update a contract|
 |[**updateDateCustomField**](#updatedatecustomfield) | **PATCH** /custom-fields/date/{dateFieldId} | Update a date custom field|
 |[**updatePeopleTag**](#updatepeopletag) | **PATCH** /people-tags/{peopleTagId} | Update a people tag|
-|[**updatePerson**](#updateperson) | **PATCH** /people/{personId} | Update a person|
-|[**updatePersonCheckboxCustomField**](#updatepersoncheckboxcustomfield) | **PATCH** /people/{personId}/custom-fields/checkbox/ | Add a checkbox custom value to a person|
-|[**updatePersonDateCustomField**](#updatepersondatecustomfield) | **PATCH** /people/{personId}/custom-fields/date/ | Add a date custom value to a person|
-|[**updatePersonSelectCustomField**](#updatepersonselectcustomfield) | **PATCH** /people/{personId}/custom-fields/select/ | Add custom select options to a person|
-|[**updatePersonSkill**](#updatepersonskill) | **PATCH** /people/{personId}/skills/{skillId} | Update a skill for a person|
-|[**updatePersonTextCustomField**](#updatepersontextcustomfield) | **PATCH** /people/{personId}/custom-fields/text/ | Add a text custom value to a person|
+|[**updatePerson**](#updateperson) | **PATCH** /people/{personId} | Update a person or placeholder|
+|[**updatePersonCheckboxCustomField**](#updatepersoncheckboxcustomfield) | **PATCH** /people/{personId}/custom-fields/checkbox/ | Add a checkbox custom value to a person or placeholder|
+|[**updatePersonDateCustomField**](#updatepersondatecustomfield) | **PATCH** /people/{personId}/custom-fields/date/ | Add a date custom value to a person or placeholder|
+|[**updatePersonSelectCustomField**](#updatepersonselectcustomfield) | **PATCH** /people/{personId}/custom-fields/select/ | Add custom select options to a person or placeholder|
+|[**updatePersonSkill**](#updatepersonskill) | **PATCH** /people/{personId}/skills/{skillId} | Update a skill for a person or placeholder|
+|[**updatePersonTextCustomField**](#updatepersontextcustomfield) | **PATCH** /people/{personId}/custom-fields/text/ | Add a text custom value to a person or placeholder|
 |[**updateProject**](#updateproject) | **PATCH** /projects/{projectId} | Update a project|
 |[**updateProjectBudgetRole**](#updateprojectbudgetrole) | **PATCH** /projects/{projectId}/budget-roles/{roleId} | Update a project budget role|
 |[**updateProjectCheckboxCustomField**](#updateprojectcheckboxcustomfield) | **PATCH** /projects/{projectId}/custom-fields/checkbox/ | Add a checkbox custom value to a project|
@@ -190,6 +192,7 @@ All URIs are relative to *https://api.runn.io*
 |[**updateProjectTag**](#updateprojecttag) | **PATCH** /project-tags/{projectTagId} | Update a project tag|
 |[**updateProjectTextCustomField**](#updateprojecttextcustomfield) | **PATCH** /projects/{projectId}/custom-fields/text/ | Add a text custom field value to a project|
 |[**updateProjectTimesheetLock**](#updateprojecttimesheetlock) | **PATCH** /projects/{projectId}/timesheet-lock/ | Update a timesheet lock for a project|
+|[**updateRateCard**](#updateratecard) | **PATCH** /rate-cards/{rateCardId} | Update a rate card|
 |[**updateRole**](#updaterole) | **PATCH** /roles/{roleId} | Update a role|
 |[**updateSelectCustomField**](#updateselectcustomfield) | **PATCH** /custom-fields/select/{selectFieldId} | Update a select custom field|
 |[**updateSelectCustomFieldOption**](#updateselectcustomfieldoption) | **PATCH** /custom-fields/select/{selectFieldId}/options/{selectOptionId} | Update a select custom field option|
@@ -380,6 +383,7 @@ void (empty response body)
 # **addPersonToTeam**
 > addPersonToTeam(addPersonToTeamRequest)
 
+This endpoint is deprecated. You may assign the person to a team using the `PATCH /people/:personId/` endpoint.
 
 ### Example
 
@@ -788,7 +792,7 @@ const { status, data } = await apiInstance.convertLegacyId(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createActual**
-> Actual createActual()
+> Actual createActual(actualInput)
 
 Minutes values represent the total time for a day and overwrite any previous actual on the same day (for the same project/person/role/workstream). [Learn more](https://developer.runn.io/docs/actuals-notes).
 
@@ -805,7 +809,7 @@ const configuration = new Configuration();
 const apiInstance = new DefaultApi(configuration);
 
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let actualInput: ActualInput; // (optional)
+let actualInput: ActualInput; //
 
 const { status, data } = await apiInstance.createActual(
     acceptVersion,
@@ -896,7 +900,7 @@ const { status, data } = await apiInstance.createActualsBulk(
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 |**200** | Default Response |  -  |
-|**400** | Invalid actualId format. |  -  |
+|**400** | Default Response |  -  |
 |**401** | Default Response |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
@@ -1015,7 +1019,7 @@ const { status, data } = await apiInstance.createCheckboxCustomField(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createClient**
-> Client createClient()
+> Client createClient(clientInput)
 
 
 ### Example
@@ -1031,7 +1035,7 @@ const configuration = new Configuration();
 const apiInstance = new DefaultApi(configuration);
 
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let clientInput: ClientInput; // (optional)
+let clientInput: ClientInput; //
 
 const { status, data } = await apiInstance.createClient(
     acceptVersion,
@@ -1183,7 +1187,7 @@ const { status, data } = await apiInstance.createDateCustomField(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createHolidayTimeOff**
-> TimeOff createHolidayTimeOff()
+> TimeOff createHolidayTimeOff(timeOffHolidayInput)
 
 
 ### Example
@@ -1199,7 +1203,7 @@ const configuration = new Configuration();
 const apiInstance = new DefaultApi(configuration);
 
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let timeOffHolidayInput: TimeOffHolidayInput; // (optional)
+let timeOffHolidayInput: TimeOffHolidayInput; //
 
 const { status, data } = await apiInstance.createHolidayTimeOff(
     acceptVersion,
@@ -1240,7 +1244,7 @@ const { status, data } = await apiInstance.createHolidayTimeOff(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createInvitation**
-> Invitation createInvitation()
+> Invitation createInvitation(createInvitationRequest)
 
 
 ### Example
@@ -1256,7 +1260,7 @@ const configuration = new Configuration();
 const apiInstance = new DefaultApi(configuration);
 
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let createInvitationRequest: CreateInvitationRequest; // (optional)
+let createInvitationRequest: CreateInvitationRequest; //
 
 const { status, data } = await apiInstance.createInvitation(
     acceptVersion,
@@ -1297,7 +1301,7 @@ const { status, data } = await apiInstance.createInvitation(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createLeaveTimeOff**
-> TimeOff createLeaveTimeOff()
+> TimeOff createLeaveTimeOff(timeOffLeaveInput)
 
  #### Create or Update  This endpoint may return an existing time off if the new time off is a subset of an existing one.  #### Automatic Merging  If one or more existing time offs overlap with the specified start/end date, they will be automatically merged.  #### Partial Time Offs  If the `minutesPerDay` field is provided, automatic merging will only occur if any overlapping time off has the same `minutesPerDay` value. If the `minutesPerDay` value differs, the request will fail.
 
@@ -1314,7 +1318,7 @@ const configuration = new Configuration();
 const apiInstance = new DefaultApi(configuration);
 
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let timeOffLeaveInput: TimeOffLeaveInput; // (optional)
+let timeOffLeaveInput: TimeOffLeaveInput; //
 
 const { status, data } = await apiInstance.createLeaveTimeOff(
     acceptVersion,
@@ -1587,7 +1591,7 @@ const { status, data } = await apiInstance.createPerson(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createPersonContract**
-> Contract createPersonContract()
+> Contract createPersonContract(contractInput)
 
 
 ### Example
@@ -1604,7 +1608,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let personId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let contractInput: ContractInput; // (optional)
+let contractInput: ContractInput; //
 
 const { status, data } = await apiInstance.createPersonContract(
     personId,
@@ -1705,7 +1709,7 @@ const { status, data } = await apiInstance.createPlaceholder(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createProject**
-> Project createProject()
+> Project createProject(createProjectRequest)
 
 
 ### Example
@@ -1721,7 +1725,7 @@ const configuration = new Configuration();
 const apiInstance = new DefaultApi(configuration);
 
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let createProjectRequest: CreateProjectRequest; // (optional)
+let createProjectRequest: CreateProjectRequest; //
 
 const { status, data } = await apiInstance.createProject(
     acceptVersion,
@@ -1761,7 +1765,7 @@ const { status, data } = await apiInstance.createProject(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **createProjectBudgetRole**
-> createProjectBudgetRole()
+> createProjectBudgetRole(createProjectBudgetRoleRequest)
 
 Create a project budget role for a project. You cannot create a              project budget role using estimated budget if a project rate does              not exist for the role because the project rate is used to set              the estimatedMinutes.
 
@@ -1779,7 +1783,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let projectId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let createProjectBudgetRoleRequest: CreateProjectBudgetRoleRequest; // (optional)
+let createProjectBudgetRoleRequest: CreateProjectBudgetRoleRequest; //
 
 const { status, data } = await apiInstance.createProjectBudgetRole(
     projectId,
@@ -3071,7 +3075,7 @@ void (empty response body)
 # **deletePerson**
 > deletePerson()
 
-Delete a person by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
+Delete a person or placeholder by their ID; fails when person has existing assignments or actuals to preserve           historical reports. Override this behaviour by using the force query flag.
 
 ### Example
 
@@ -4306,6 +4310,7 @@ const { status, data } = await apiInstance.getPersonCurrentContract(
 # **getPersonCurrentTeam**
 > GetPersonCurrentTeam200Response getPersonCurrentTeam()
 
+This endpoint is deprecated. You may view the current team for a person using the `GET /people/:personId/` endpoint.
 
 ### Example
 
@@ -4427,6 +4432,67 @@ const { status, data } = await apiInstance.getPersonHoursReport(
 |**200** | Default Response |  -  |
 |**401** | Default Response |  -  |
 |**404** | Default Response |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **getPersonReport**
+> GetPersonReport200Response getPersonReport()
+
+Get a report for a person containing data from the People Overview Report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+
+### Example
+
+```typescript
+import {
+    DefaultApi,
+    Configuration
+} from 'runn-typescript-sdk';
+
+const configuration = new Configuration();
+const apiInstance = new DefaultApi(configuration);
+
+let personId: number; // (default to undefined)
+let acceptVersion: '1.0.0'; // (default to '1.0.0')
+let startDate: string; //The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD (optional) (default to undefined)
+let periodType: 'monthly' | 'weekly' | 'quarterly'; //The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. (optional) (default to 'monthly')
+
+const { status, data } = await apiInstance.getPersonReport(
+    personId,
+    acceptVersion,
+    startDate,
+    periodType
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **personId** | [**number**] |  | defaults to undefined|
+| **acceptVersion** | [**&#39;1.0.0&#39;**]**Array<&#39;1.0.0&#39;>** |  | defaults to '1.0.0'|
+| **startDate** | [**string**] | The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD | (optional) defaults to undefined|
+| **periodType** | [**&#39;monthly&#39; | &#39;weekly&#39; | &#39;quarterly&#39;**]**Array<&#39;monthly&#39; &#124; &#39;weekly&#39; &#124; &#39;quarterly&#39;>** | The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. | (optional) defaults to 'monthly'|
+
+
+### Return type
+
+**GetPersonReport200Response**
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**200** | Default Response |  -  |
+|**401** | Default Response |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -4721,6 +4787,68 @@ const { status, data } = await apiInstance.getProjectPhase(
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 |**200** | Project phases divide your project into smaller sections so you can group similar tasks and assignments together. |  -  |
+|**401** | Default Response |  -  |
+|**404** | Default Response |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **getProjectReport**
+> GetProjectReport200Response getProjectReport()
+
+Get a report for a project containing data from the Project Overview report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.
+
+### Example
+
+```typescript
+import {
+    DefaultApi,
+    Configuration
+} from 'runn-typescript-sdk';
+
+const configuration = new Configuration();
+const apiInstance = new DefaultApi(configuration);
+
+let projectId: number; // (default to undefined)
+let acceptVersion: '1.0.0'; // (default to '1.0.0')
+let startDate: string; //The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD (optional) (default to undefined)
+let periodType: 'monthly' | 'weekly' | 'quarterly'; //The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. If not provided, the report will be for the Overview report (all inclusive). (optional) (default to undefined)
+
+const { status, data } = await apiInstance.getProjectReport(
+    projectId,
+    acceptVersion,
+    startDate,
+    periodType
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **projectId** | [**number**] |  | defaults to undefined|
+| **acceptVersion** | [**&#39;1.0.0&#39;**]**Array<&#39;1.0.0&#39;>** |  | defaults to '1.0.0'|
+| **startDate** | [**string**] | The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD | (optional) defaults to undefined|
+| **periodType** | [**&#39;monthly&#39; | &#39;weekly&#39; | &#39;quarterly&#39;**]**Array<&#39;monthly&#39; &#124; &#39;weekly&#39; &#124; &#39;quarterly&#39;>** | The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. If not provided, the report will be for the Overview report (all inclusive). | (optional) defaults to undefined|
+
+
+### Return type
+
+**GetProjectReport200Response**
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**200** | Default Response |  -  |
 |**401** | Default Response |  -  |
 |**404** | Default Response |  -  |
 
@@ -6465,7 +6593,7 @@ let includePlaceholders: boolean; // (optional) (default to false)
 let email: string; //If provided, will only return people with an email that are a substring of this value (case-insensitive). (optional) (default to undefined)
 let firstName: string; //If provided, will only return people with a first name that is a substring of this value (case-insensitive). (optional) (default to undefined)
 let lastName: string; //If provided, will only return people with a last name that is a substring of this value (case-insensitive). (optional) (default to undefined)
-let modifiedAfter: ModifiedAfter; //If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A person is considered \"modified\" if any of its core properties change. Actions that count as modifying a person include changing first name, last name, email, references, tags and archiving. A person is not considered modified just because another object it is associated with is changed (e.g. a contract, project or an assignment). (optional) (default to undefined)
+let modifiedAfter: ModifiedAfter; // (optional) (default to undefined)
 let externalId: string; //External ID value (optional) (default to undefined)
 
 const { status, data } = await apiInstance.listPeople(
@@ -6496,7 +6624,7 @@ const { status, data } = await apiInstance.listPeople(
 | **email** | [**string**] | If provided, will only return people with an email that are a substring of this value (case-insensitive). | (optional) defaults to undefined|
 | **firstName** | [**string**] | If provided, will only return people with a first name that is a substring of this value (case-insensitive). | (optional) defaults to undefined|
 | **lastName** | [**string**] | If provided, will only return people with a last name that is a substring of this value (case-insensitive). | (optional) defaults to undefined|
-| **modifiedAfter** | **ModifiedAfter** | If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A person is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a person include changing first name, last name, email, references, tags and archiving. A person is not considered modified just because another object it is associated with is changed (e.g. a contract, project or an assignment). | (optional) defaults to undefined|
+| **modifiedAfter** | **ModifiedAfter** |  | (optional) defaults to undefined|
 | **externalId** | [**string**] | External ID value | (optional) defaults to undefined|
 
 
@@ -6733,7 +6861,7 @@ let acceptVersion: '1.0.0'; // (default to '1.0.0')
 let cursor: string; //Cursor for paginated requests (optional) (default to undefined)
 let limit: number; //The number of results per page (optional) (default to 50)
 let includePlaceholders: boolean; // (optional) (default to false)
-let modifiedAfter: ModifiedAfter; //If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. (optional) (default to undefined)
+let modifiedAfter: ModifiedAfter; // (optional) (default to undefined)
 
 const { status, data } = await apiInstance.listPeopleSkills(
     acceptVersion,
@@ -6752,7 +6880,7 @@ const { status, data } = await apiInstance.listPeopleSkills(
 | **cursor** | [**string**] | Cursor for paginated requests | (optional) defaults to undefined|
 | **limit** | [**number**] | The number of results per page | (optional) defaults to 50|
 | **includePlaceholders** | [**boolean**] |  | (optional) defaults to false|
-| **modifiedAfter** | **ModifiedAfter** | If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. | (optional) defaults to undefined|
+| **modifiedAfter** | **ModifiedAfter** |  | (optional) defaults to undefined|
 
 
 ### Return type
@@ -7497,6 +7625,7 @@ const { status, data } = await apiInstance.listPhases(
 # **listPlaceholders**
 > ListPlaceholders200Response listPlaceholders()
 
+Note: The /people/_* endpoints also allows getting information on placeholders when using the `includePlaceholders` query parameter.
 
 ### Example
 
@@ -8685,7 +8814,7 @@ let cursor: string; //Cursor for paginated requests (optional) (default to undef
 let limit: number; //The number of results per page (optional) (default to 50)
 let sortBy: 'createdAt' | 'updatedAt' | 'id'; //Field to sort by: createdAt or updatedAt or id (optional) (default to 'id')
 let order: 'asc' | 'desc'; //Sort order: asc or desc (optional) (default to 'asc')
-let modifiedAfter: ModifiedAfter; //If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A project is considered \"modified\" if any of its core properties change. Actions that count as modifying a project include changing the name, client, status, pricing model, rate type , team, budget, expenses budget, references, and archiving. A project is not considered modified just because another object it is associated with is changed (e.g. actuals, assignments, budget roles, custom fields, milestones, notes, other expenses, people, people requests, phases, rates, timesheet locks & workstreams). (optional) (default to undefined)
+let modifiedAfter: ModifiedAfter; // (optional) (default to undefined)
 let externalId: string; //External ID value (optional) (default to undefined)
 let name: string; //Case-insensitive substring match on project name (e.g. `Acme`). (optional) (default to undefined)
 
@@ -8712,7 +8841,7 @@ const { status, data } = await apiInstance.listProjects(
 | **limit** | [**number**] | The number of results per page | (optional) defaults to 50|
 | **sortBy** | [**&#39;createdAt&#39; | &#39;updatedAt&#39; | &#39;id&#39;**]**Array<&#39;createdAt&#39; &#124; &#39;updatedAt&#39; &#124; &#39;id&#39;>** | Field to sort by: createdAt or updatedAt or id | (optional) defaults to 'id'|
 | **order** | [**&#39;asc&#39; | &#39;desc&#39;**]**Array<&#39;asc&#39; &#124; &#39;desc&#39;>** | Sort order: asc or desc | (optional) defaults to 'asc'|
-| **modifiedAfter** | **ModifiedAfter** | If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A project is considered \&quot;modified\&quot; if any of its core properties change. Actions that count as modifying a project include changing the name, client, status, pricing model, rate type , team, budget, expenses budget, references, and archiving. A project is not considered modified just because another object it is associated with is changed (e.g. actuals, assignments, budget roles, custom fields, milestones, notes, other expenses, people, people requests, phases, rates, timesheet locks &amp; workstreams). | (optional) defaults to undefined|
+| **modifiedAfter** | **ModifiedAfter** |  | (optional) defaults to undefined|
 | **externalId** | [**string**] | External ID value | (optional) defaults to undefined|
 | **name** | [**string**] | Case-insensitive substring match on project name (e.g. &#x60;Acme&#x60;). | (optional) defaults to undefined|
 
@@ -9588,6 +9717,7 @@ const { status, data } = await apiInstance.listWorkstreams(
 # **removePersonFromTeam**
 > removePersonFromTeam()
 
+This endpoint is deprecated. You may remove the person from a team using the `PATCH /people/:personId/` endpoint.
 
 ### Example
 
@@ -9999,7 +10129,7 @@ const { status, data } = await apiInstance.removeWorkstreamFromProject(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateActualTimeEntry**
-> Actual updateActualTimeEntry()
+> Actual updateActualTimeEntry(actualTimeEntry)
 
 Returns Actual with updated minutes. Creates a new actual when there is none to update [Learn more](https://developer.runn.io/docs/actuals-notes).
 
@@ -10016,7 +10146,7 @@ const configuration = new Configuration();
 const apiInstance = new DefaultApi(configuration);
 
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let actualTimeEntry: ActualTimeEntry; // (optional)
+let actualTimeEntry: ActualTimeEntry; //
 
 const { status, data } = await apiInstance.updateActualTimeEntry(
     acceptVersion,
@@ -10056,7 +10186,7 @@ const { status, data } = await apiInstance.updateActualTimeEntry(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateCheckboxCustomField**
-> CustomFieldCheckbox updateCheckboxCustomField()
+> CustomFieldCheckbox updateCheckboxCustomField(updateCheckboxCustomFieldRequest)
 
 
 ### Example
@@ -10073,7 +10203,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let checkboxFieldId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest; // (optional)
+let updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest; //
 
 const { status, data } = await apiInstance.updateCheckboxCustomField(
     checkboxFieldId,
@@ -10116,7 +10246,7 @@ const { status, data } = await apiInstance.updateCheckboxCustomField(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateClient**
-> Client updateClient()
+> Client updateClient(updateClientRequest)
 
 
 ### Example
@@ -10133,7 +10263,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let clientId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateClientRequest: UpdateClientRequest; // (optional)
+let updateClientRequest: UpdateClientRequest; //
 
 const { status, data } = await apiInstance.updateClient(
     clientId,
@@ -10175,7 +10305,7 @@ const { status, data } = await apiInstance.updateClient(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateContract**
-> Contract updateContract()
+> Contract updateContract(updateContractRequest)
 
 Update a contract
 
@@ -10193,7 +10323,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let contractId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateContractRequest: UpdateContractRequest; // (optional)
+let updateContractRequest: UpdateContractRequest; //
 
 const { status, data } = await apiInstance.updateContract(
     contractId,
@@ -10236,7 +10366,7 @@ const { status, data } = await apiInstance.updateContract(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateDateCustomField**
-> CustomFieldDate updateDateCustomField()
+> CustomFieldDate updateDateCustomField(updateDateCustomFieldRequest)
 
 
 ### Example
@@ -10253,7 +10383,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let dateFieldId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateDateCustomFieldRequest: UpdateDateCustomFieldRequest; // (optional)
+let updateDateCustomFieldRequest: UpdateDateCustomFieldRequest; //
 
 const { status, data } = await apiInstance.updateDateCustomField(
     dateFieldId,
@@ -10355,7 +10485,7 @@ const { status, data } = await apiInstance.updatePeopleTag(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updatePerson**
-> Person updatePerson()
+> Person updatePerson(updatePersonRequest)
 
 To add a new role or job title to a person, see POST /people/{personId}/contracts
 
@@ -10373,7 +10503,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let personId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updatePersonRequest: UpdatePersonRequest; // (optional)
+let updatePersonRequest: UpdatePersonRequest; //
 
 const { status, data } = await apiInstance.updatePerson(
     personId,
@@ -10718,7 +10848,7 @@ const { status, data } = await apiInstance.updatePersonTextCustomField(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateProject**
-> Project updateProject()
+> Project updateProject(updateProjectRequest)
 
 
 ### Example
@@ -10735,7 +10865,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let projectId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateProjectRequest: UpdateProjectRequest; // (optional)
+let updateProjectRequest: UpdateProjectRequest; //
 
 const { status, data } = await apiInstance.updateProject(
     projectId,
@@ -10778,7 +10908,7 @@ const { status, data } = await apiInstance.updateProject(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateProjectBudgetRole**
-> ProjectBudgetRole updateProjectBudgetRole()
+> ProjectBudgetRole updateProjectBudgetRole(updateProjectBudgetRoleRequest)
 
 Update a project budget role for a project. You cannot update a              project budget role using estimated budget if a project rate does              not exist for the role because the project rate is used to set              the estimatedMinutes.
 
@@ -10797,7 +10927,7 @@ const apiInstance = new DefaultApi(configuration);
 let projectId: number; // (default to undefined)
 let roleId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateProjectBudgetRoleRequest: UpdateProjectBudgetRoleRequest; // (optional)
+let updateProjectBudgetRoleRequest: UpdateProjectBudgetRoleRequest; //
 
 const { status, data } = await apiInstance.updateProjectBudgetRole(
     projectId,
@@ -10961,7 +11091,7 @@ const { status, data } = await apiInstance.updateProjectDateCustomField(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateProjectMilestone**
-> Milestone updateProjectMilestone()
+> Milestone updateProjectMilestone(updateProjectMilestoneRequest)
 
 
 ### Example
@@ -10979,7 +11109,7 @@ const apiInstance = new DefaultApi(configuration);
 let projectId: number; // (default to undefined)
 let milestoneId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateProjectMilestoneRequest: UpdateProjectMilestoneRequest; // (optional)
+let updateProjectMilestoneRequest: UpdateProjectMilestoneRequest; //
 
 const { status, data } = await apiInstance.updateProjectMilestone(
     projectId,
@@ -11024,7 +11154,7 @@ const { status, data } = await apiInstance.updateProjectMilestone(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateProjectOtherExpense**
-> ProjectOtherExpense updateProjectOtherExpense()
+> ProjectOtherExpense updateProjectOtherExpense(projectOtherExpense1)
 
 
 ### Example
@@ -11042,7 +11172,7 @@ const apiInstance = new DefaultApi(configuration);
 let projectId: number; //Unique identifier for the project the expense is for. (default to undefined)
 let otherExpenseId: number; //Unique identifier for the other expense to update. (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let projectOtherExpense1: ProjectOtherExpense1; //A non-labour expense for a project. (optional)
+let projectOtherExpense1: ProjectOtherExpense1; //A non-labour expense for a project.
 
 const { status, data } = await apiInstance.updateProjectOtherExpense(
     projectId,
@@ -11150,7 +11280,7 @@ const { status, data } = await apiInstance.updateProjectPersonRequest(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateProjectPhase**
-> ProjectPhase updateProjectPhase()
+> ProjectPhase updateProjectPhase(updateProjectPhaseRequest)
 
 
 ### Example
@@ -11168,7 +11298,7 @@ const apiInstance = new DefaultApi(configuration);
 let projectId: number; // (default to undefined)
 let phaseId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateProjectPhaseRequest: UpdateProjectPhaseRequest; // (optional)
+let updateProjectPhaseRequest: UpdateProjectPhaseRequest; //
 
 const { status, data } = await apiInstance.updateProjectPhase(
     projectId,
@@ -11452,7 +11582,7 @@ const { status, data } = await apiInstance.updateProjectTextCustomField(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateProjectTimesheetLock**
-> GetProjectTimesheetLock200Response updateProjectTimesheetLock()
+> GetProjectTimesheetLock200Response updateProjectTimesheetLock(updateProjectTimesheetLockRequest)
 
 This feature currently in beta and only available to selected customers.This will return an error and message if all timesheets haven\'t been filled out to selected date.
 
@@ -11470,7 +11600,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let projectId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateProjectTimesheetLockRequest: UpdateProjectTimesheetLockRequest; // (optional)
+let updateProjectTimesheetLockRequest: UpdateProjectTimesheetLockRequest; //
 
 const { status, data } = await apiInstance.updateProjectTimesheetLock(
     projectId,
@@ -11511,8 +11641,68 @@ const { status, data } = await apiInstance.updateProjectTimesheetLock(
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **updateRateCard**
+> RateCard updateRateCard(updateRateCardRequest)
+
+
+### Example
+
+```typescript
+import {
+    DefaultApi,
+    Configuration,
+    UpdateRateCardRequest
+} from 'runn-typescript-sdk';
+
+const configuration = new Configuration();
+const apiInstance = new DefaultApi(configuration);
+
+let rateCardId: number; // (default to undefined)
+let acceptVersion: '1.0.0'; // (default to '1.0.0')
+let updateRateCardRequest: UpdateRateCardRequest; //
+
+const { status, data } = await apiInstance.updateRateCard(
+    rateCardId,
+    acceptVersion,
+    updateRateCardRequest
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **updateRateCardRequest** | **UpdateRateCardRequest**|  | |
+| **rateCardId** | [**number**] |  | defaults to undefined|
+| **acceptVersion** | [**&#39;1.0.0&#39;**]**Array<&#39;1.0.0&#39;>** |  | defaults to '1.0.0'|
+
+
+### Return type
+
+**RateCard**
+
+### Authorization
+
+[bearerAuth](../README.md#bearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**200** | Default Response |  -  |
+|**400** | Default Response |  -  |
+|**401** | Default Response |  -  |
+|**404** | Default Response |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **updateRole**
-> Role updateRole()
+> Role updateRole(updateRoleRequest)
 
 
 ### Example
@@ -11529,7 +11719,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let roleId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateRoleRequest: UpdateRoleRequest; // (optional)
+let updateRoleRequest: UpdateRoleRequest; //
 
 const { status, data } = await apiInstance.updateRole(
     roleId,
@@ -11571,7 +11761,7 @@ const { status, data } = await apiInstance.updateRole(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateSelectCustomField**
-> CustomFieldSelect updateSelectCustomField()
+> CustomFieldSelect updateSelectCustomField(updateCheckboxCustomFieldRequest)
 
 
 ### Example
@@ -11588,7 +11778,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let selectFieldId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest; // (optional)
+let updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest; //
 
 const { status, data } = await apiInstance.updateSelectCustomField(
     selectFieldId,
@@ -11814,7 +12004,7 @@ const { status, data } = await apiInstance.updateTeam(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateTextCustomField**
-> CustomFieldText updateTextCustomField()
+> CustomFieldText updateTextCustomField(updateCheckboxCustomFieldRequest)
 
 
 ### Example
@@ -11831,7 +12021,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let textFieldId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest; // (optional)
+let updateCheckboxCustomFieldRequest: UpdateCheckboxCustomFieldRequest; //
 
 const { status, data } = await apiInstance.updateTextCustomField(
     textFieldId,
@@ -11874,7 +12064,7 @@ const { status, data } = await apiInstance.updateTextCustomField(
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **updateWorkstream**
-> Workstream updateWorkstream()
+> Workstream updateWorkstream(updateWorkstreamRequest)
 
 
 ### Example
@@ -11891,7 +12081,7 @@ const apiInstance = new DefaultApi(configuration);
 
 let workstreamId: number; // (default to undefined)
 let acceptVersion: '1.0.0'; // (default to '1.0.0')
-let updateWorkstreamRequest: UpdateWorkstreamRequest; // (optional)
+let updateWorkstreamRequest: UpdateWorkstreamRequest; //
 
 const { status, data } = await apiInstance.updateWorkstream(
     workstreamId,

--- a/docs/GetPersonReport200Response.md
+++ b/docs/GetPersonReport200Response.md
@@ -1,0 +1,34 @@
+# GetPersonReport200Response
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **number** |  | [default to undefined]
+**firstName** | **string** |  | [default to undefined]
+**lastName** | **string** |  | [default to undefined]
+**email** | **string** |  | [default to undefined]
+**jobTitle** | **string** |  | [default to undefined]
+**team** | **string** |  | [default to undefined]
+**employmentType** | **string** |  | [default to undefined]
+**metrics** | [**Array&lt;GetPersonReport200ResponseMetricsInner&gt;**](GetPersonReport200ResponseMetricsInner.md) |  | [default to undefined]
+
+## Example
+
+```typescript
+import { GetPersonReport200Response } from 'runn-typescript-sdk';
+
+const instance: GetPersonReport200Response = {
+    id,
+    firstName,
+    lastName,
+    email,
+    jobTitle,
+    team,
+    employmentType,
+    metrics,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/GetPersonReport200ResponseMetricsInner.md
+++ b/docs/GetPersonReport200ResponseMetricsInner.md
@@ -1,0 +1,50 @@
+# GetPersonReport200ResponseMetricsInner
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**startDate** | **string** |  | [default to undefined]
+**endDate** | **string** |  | [default to undefined]
+**revenue** | **number** |  | [default to undefined]
+**projectCosts** | **number** |  | [default to undefined]
+**businessCosts** | **number** |  | [default to undefined]
+**totalEffortHours** | **number** |  | [default to undefined]
+**billableEffortHours** | **number** |  | [default to undefined]
+**nonBillableEffortHours** | **number** |  | [default to undefined]
+**totalUtilization** | **number** |  | [default to undefined]
+**billableUtilization** | **number** |  | [default to undefined]
+**contractCapacity** | **number** |  | [default to undefined]
+**effectiveCapacity** | **number** |  | [default to undefined]
+**overtime** | **number** |  | [default to undefined]
+**remainingAvailability** | **number** |  | [default to undefined]
+**timeOffHours** | **number** |  | [default to undefined]
+**completedTimesheet** | **boolean** |  | [default to undefined]
+
+## Example
+
+```typescript
+import { GetPersonReport200ResponseMetricsInner } from 'runn-typescript-sdk';
+
+const instance: GetPersonReport200ResponseMetricsInner = {
+    startDate,
+    endDate,
+    revenue,
+    projectCosts,
+    businessCosts,
+    totalEffortHours,
+    billableEffortHours,
+    nonBillableEffortHours,
+    totalUtilization,
+    billableUtilization,
+    contractCapacity,
+    effectiveCapacity,
+    overtime,
+    remainingAvailability,
+    timeOffHours,
+    completedTimesheet,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/GetProjectReport200Response.md
+++ b/docs/GetProjectReport200Response.md
@@ -1,0 +1,34 @@
+# GetProjectReport200Response
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **number** |  | [default to undefined]
+**name** | **string** |  | [default to undefined]
+**period** | **string** |  | [optional] [default to undefined]
+**pricingModel** | **string** |  | [default to undefined]
+**budget** | **number** |  | [default to undefined]
+**budgetRemaining** | **number** |  | [default to undefined]
+**timeBudgetRemaining** | **number** |  | [default to undefined]
+**metrics** | [**Array&lt;GetProjectReport200ResponseMetricsInner&gt;**](GetProjectReport200ResponseMetricsInner.md) |  | [default to undefined]
+
+## Example
+
+```typescript
+import { GetProjectReport200Response } from 'runn-typescript-sdk';
+
+const instance: GetProjectReport200Response = {
+    id,
+    name,
+    period,
+    pricingModel,
+    budget,
+    budgetRemaining,
+    timeBudgetRemaining,
+    metrics,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/GetProjectReport200ResponseMetricsInner.md
+++ b/docs/GetProjectReport200ResponseMetricsInner.md
@@ -1,0 +1,38 @@
+# GetProjectReport200ResponseMetricsInner
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**startDate** | **string** |  | [default to undefined]
+**endDate** | **string** |  | [default to undefined]
+**timeMaterialsBenchmark** | **number** |  | [default to undefined]
+**revenue** | **number** |  | [default to undefined]
+**profit** | **number** |  | [default to undefined]
+**costs** | **number** |  | [default to undefined]
+**margin** | **number** | Percentage value of the profit margin | [default to undefined]
+**totalEffortHours** | **number** |  | [default to undefined]
+**billableEffortHours** | **number** |  | [default to undefined]
+**nonBillableEffortHours** | **number** |  | [default to undefined]
+
+## Example
+
+```typescript
+import { GetProjectReport200ResponseMetricsInner } from 'runn-typescript-sdk';
+
+const instance: GetProjectReport200ResponseMetricsInner = {
+    startDate,
+    endDate,
+    timeMaterialsBenchmark,
+    revenue,
+    profit,
+    costs,
+    margin,
+    totalEffortHours,
+    billableEffortHours,
+    nonBillableEffortHours,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/GetProjectReport404Response.md
+++ b/docs/GetProjectReport404Response.md
@@ -1,0 +1,20 @@
+# GetProjectReport404Response
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**message** | **string** |  | [default to undefined]
+
+## Example
+
+```typescript
+import { GetProjectReport404Response } from 'runn-typescript-sdk';
+
+const instance: GetProjectReport404Response = {
+    message,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/Invitation.md
+++ b/docs/Invitation.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **userType** | **string** | Permission level | [default to undefined]
 **financialPermission** | **string** | Financial permission level | [default to undefined]
 **editProjectsPermission** | **string** | Edit projects permission level (deprecated: use manageProjectsPermission) | [default to undefined]
-**editOthersPermission** | **string** | Edit others permission level | [default to undefined]
+**editOthersPermission** | **string** | Edit others permission level (deprecated: use managePeoplePermission) | [default to undefined]
 **manageProjectsPermission** | **string** | Manage projects permission level | [default to undefined]
 **managePeoplePermission** | **string** | Manage people permission level | [default to undefined]
 **manageAccountPermission** | **boolean** | Manage account permission level | [default to undefined]

--- a/docs/UpdatePersonRequest.md
+++ b/docs/UpdatePersonRequest.md
@@ -9,8 +9,10 @@ Name | Type | Description | Notes
 **lastName** | **string** |  | [optional] [default to undefined]
 **email** | **string** |  | [optional] [default to undefined]
 **tags** | [**Array&lt;UpdatePersonRequestTagsInner&gt;**](UpdatePersonRequestTagsInner.md) |  | [optional] [default to undefined]
+**teamId** | **number** |  | [optional] [default to undefined]
 **references** | [**Array&lt;Reference&gt;**](Reference.md) |  | [optional] [default to undefined]
 **isArchived** | **boolean** |  | [optional] [default to undefined]
+**managers** | [**Array&lt;UpdatePersonRequestManagersInner&gt;**](UpdatePersonRequestManagersInner.md) |  | [optional] [default to undefined]
 
 ## Example
 
@@ -22,8 +24,10 @@ const instance: UpdatePersonRequest = {
     lastName,
     email,
     tags,
+    teamId,
     references,
     isArchived,
+    managers,
 };
 ```
 

--- a/docs/UpdatePersonRequestManagersInner.md
+++ b/docs/UpdatePersonRequestManagersInner.md
@@ -1,0 +1,20 @@
+# UpdatePersonRequestManagersInner
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**userId** | **number** |  | [default to undefined]
+
+## Example
+
+```typescript
+import { UpdatePersonRequestManagersInner } from 'runn-typescript-sdk';
+
+const instance: UpdatePersonRequestManagersInner = {
+    userId,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/UpdateRateCardRequest.md
+++ b/docs/UpdateRateCardRequest.md
@@ -1,0 +1,30 @@
+# UpdateRateCardRequest
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | **string** |  | [optional] [default to undefined]
+**description** | **string** |  | [optional] [default to undefined]
+**references** | [**Array&lt;CreateRateCardRequestReferencesInner&gt;**](CreateRateCardRequestReferencesInner.md) |  | [optional] [default to undefined]
+**isBlendedRateCard** | **boolean** |  | [optional] [default to undefined]
+**blendedRate** | **number** |  | [optional] [default to undefined]
+**rateType** | **string** |  | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { UpdateRateCardRequest } from 'runn-typescript-sdk';
+
+const instance: UpdateRateCardRequest = {
+    name,
+    description,
+    references,
+    isBlendedRateCard,
+    blendedRate,
+    rateType,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/docs/UserPermissions.md
+++ b/docs/UserPermissions.md
@@ -7,9 +7,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **type** | **string** |  | [default to undefined]
 **financial** | **string** |  | [default to undefined]
-**editProjects** | **string** |  | [default to undefined]
+**editProjects** | **string** | Edit projects permission (deprecated: use manageProjects) | [default to undefined]
 **manageProjects** | **string** |  | [default to undefined]
-**editOthers** | **string** |  | [default to undefined]
+**editOthers** | **string** | Edit others permission (deprecated: use managePeople) | [default to undefined]
 **managePeople** | **string** |  | [default to undefined]
 **manageAccount** | **boolean** |  | [default to undefined]
 **addAllPeopleToProjects** | **boolean** |  | [default to undefined]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runn-typescript-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runn-typescript-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runn-typescript-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript SDK for the Runn API, auto-generated from OpenAPI spec",
   "author": "Rocket Science",
   "repository": {

--- a/runn.json
+++ b/runn.json
@@ -2658,8 +2658,8 @@
                 "discriminator": {
                     "propertyName": "type",
                     "mapping": {
-                        "user": "#/components/schemas/ActorUser",
                         "runn_support": "#/components/schemas/ActorRunnSupport",
+                        "user": "#/components/schemas/ActorUser",
                         "api": "#/components/schemas/ActorApi",
                         "csv": "#/components/schemas/ActorCsv",
                         "integration": "#/components/schemas/ActorIntegration",
@@ -2670,10 +2670,10 @@
                 "description": "An actor represents an entity that can perform actions such as a user, api key, or system process. Each actor type has a unique set of properties. The `type` property is used to determine the actor type.",
                 "anyOf": [
                     {
-                        "$ref": "#/components/schemas/ActorUser"
+                        "$ref": "#/components/schemas/ActorRunnSupport"
                     },
                     {
-                        "$ref": "#/components/schemas/ActorRunnSupport"
+                        "$ref": "#/components/schemas/ActorUser"
                     },
                     {
                         "$ref": "#/components/schemas/ActorApi"
@@ -3471,6 +3471,7 @@
                             "restricted",
                             "none"
                         ],
+                        "deprecated": true,
                         "description": "Edit projects permission level (deprecated: use manageProjectsPermission)"
                     },
                     "editOthersPermission": {
@@ -3479,7 +3480,8 @@
                             "all",
                             "none"
                         ],
-                        "description": "Edit others permission level"
+                        "deprecated": true,
+                        "description": "Edit others permission level (deprecated: use managePeoplePermission)"
                     },
                     "manageProjectsPermission": {
                         "type": "string",
@@ -4102,7 +4104,9 @@
                                     "specific",
                                     "restricted",
                                     "none"
-                                ]
+                                ],
+                                "deprecated": true,
+                                "description": "Edit projects permission (deprecated: use manageProjects)"
                             },
                             "manageProjects": {
                                 "type": "string",
@@ -4118,7 +4122,9 @@
                                 "enum": [
                                     "all",
                                     "none"
-                                ]
+                                ],
+                                "deprecated": true,
+                                "description": "Edit others permission (deprecated: use managePeople)"
                             },
                             "managePeople": {
                                 "type": "string",
@@ -4531,6 +4537,7 @@
                 "summary": "Create or update an actual",
                 "description": "Minutes values represent the total time for a day and overwrite any previous actual on the same day (for the same project/person/role/workstream). [Learn more](https://developer.runn.io/docs/actuals-notes).",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -4592,6 +4599,7 @@
                 "summary": "Update an actual",
                 "description": "Returns Actual with updated minutes. Creates a new actual when there is none to update [Learn more](https://developer.runn.io/docs/actuals-notes).",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -4683,8 +4691,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BadRequest",
-                                    "description": "Invalid actualId format."
+                                    "$ref": "#/components/schemas/BadRequest"
                                 }
                             }
                         }
@@ -4704,8 +4711,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/NotFound",
-                                    "description": "The actual record with the specified ID was not found."
+                                    "$ref": "#/components/schemas/NotFound"
                                 }
                             }
                         }
@@ -4719,6 +4725,7 @@
                 "summary": "Create or update actuals in bulk",
                 "description": "Create or update up to 100 'actuals' in a single API call. [Learn more](https://developer.runn.io/docs/actuals-notes).",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -4738,8 +4745,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -4769,12 +4775,21 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid actualId format.",
+                        "description": "Default Response",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BadRequest",
-                                    "description": "Invalid actualId format."
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/components/schemas/BadRequest"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Actual"
+                                            }
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -4798,6 +4813,7 @@
                 "summary": "Create an assignment",
                 "description": "Creates a new assignment and returns a list of assignments. If the specified time period of the assignment overlaps with scheduled leave, the assignment is split into multiple segments. Each segment is returned as a separate assignment in the response.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -4865,8 +4881,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -4936,7 +4951,7 @@
                         "schema": {
                             "default": 100,
                             "minimum": 1,
-                            "maximum": 500,
+                            "maximum": 200,
                             "type": "integer"
                         },
                         "in": "query",
@@ -5363,6 +5378,7 @@
             "post": {
                 "summary": "Create a client",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -5470,6 +5486,7 @@
             "patch": {
                 "summary": "Update a client",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -5671,6 +5688,7 @@
                 "summary": "Create clients in bulk",
                 "description": "Create up to 100 'clients' in a single API call. [Learn more](https://developer.runn.io/docs/clients-notes).",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -5690,8 +5708,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -5868,6 +5885,7 @@
                 "summary": "Update a contract",
                 "description": "Update a contract",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -6103,6 +6121,7 @@
             "post": {
                 "summary": "Create a checkbox custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -6145,8 +6164,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -6200,6 +6218,7 @@
             "patch": {
                 "summary": "Update a checkbox custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -6346,6 +6365,7 @@
             "post": {
                 "summary": "Create a date custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -6387,8 +6407,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -6538,59 +6557,10 @@
             }
         },
         "/custom-fields/date/{dateFieldId}": {
-            "delete": {
-                "summary": "Delete a date custom field",
-                "parameters": [
-                    {
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "name": "dateFieldId",
-                        "required": true
-                    },
-                    {
-                        "schema": {
-                            "default": "1.0.0",
-                            "enum": [
-                                "1.0.0"
-                            ]
-                        },
-                        "in": "header",
-                        "name": "accept-version",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Default Response"
-                    },
-                    "401": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Unauthorized"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/NotFound"
-                                }
-                            }
-                        }
-                    }
-                },
-                "operationId": "deleteDateCustomField"
-            },
             "patch": {
                 "summary": "Update a date custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -6680,12 +6650,63 @@
                     }
                 },
                 "operationId": "updateDateCustomField"
+            },
+            "delete": {
+                "summary": "Delete a date custom field",
+                "parameters": [
+                    {
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "name": "dateFieldId",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "default": "1.0.0",
+                            "enum": [
+                                "1.0.0"
+                            ]
+                        },
+                        "in": "header",
+                        "name": "accept-version",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Default Response"
+                    },
+                    "401": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Unauthorized"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFound"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "deleteDateCustomField"
             }
         },
         "/custom-fields/select/": {
             "post": {
                 "summary": "Create a select custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -6749,8 +6770,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -6903,6 +6923,7 @@
             "patch": {
                 "summary": "Update a select custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -7107,6 +7128,7 @@
             "patch": {
                 "summary": "Update a select custom field option",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -7122,8 +7144,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -7225,6 +7246,7 @@
             "post": {
                 "summary": "Create a select custom field option",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -7240,8 +7262,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -7335,6 +7356,7 @@
             "post": {
                 "summary": "Create a text custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -7377,8 +7399,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -7581,6 +7602,7 @@
             "patch": {
                 "summary": "Update a text custom field",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -8075,6 +8097,7 @@
             "post": {
                 "summary": "Create an invitation for a user",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -8134,6 +8157,7 @@
                                                             "restricted",
                                                             "none"
                                                         ],
+                                                        "deprecated": true,
                                                         "description": "Permissions for editing projects. (deprecated: use manageProjectsPermission)"
                                                     },
                                                     "editOthersPermission": {
@@ -8142,7 +8166,8 @@
                                                             "all",
                                                             "none"
                                                         ],
-                                                        "description": "Permissions for editing other parts of the account (people, clients, teams etc.)"
+                                                        "deprecated": true,
+                                                        "description": "Permissions for editing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission)"
                                                     }
                                                 },
                                                 "required": [
@@ -8169,7 +8194,8 @@
                                                             "all",
                                                             "none"
                                                         ],
-                                                        "description": "Permissions for managing other parts of the account (people, clients, teams etc.)"
+                                                        "deprecated": true,
+                                                        "description": "Permissions for managing other parts of the account (people, clients, teams etc.). (deprecated: use managePeoplePermission)"
                                                     }
                                                 },
                                                 "required": [
@@ -8645,7 +8671,7 @@
         },
         "/people/{personId}": {
             "get": {
-                "summary": "Show a person",
+                "summary": "Show a person or placeholder",
                 "parameters": [
                     {
                         "schema": {
@@ -8702,9 +8728,10 @@
                 "operationId": "getPerson"
             },
             "patch": {
-                "summary": "Update a person",
+                "summary": "Update a person or placeholder",
                 "description": "To add a new role or job title to a person, see POST /people/{personId}/contracts",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -8735,6 +8762,10 @@
                                             ]
                                         }
                                     },
+                                    "teamId": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    },
                                     "references": {
                                         "type": "array",
                                         "items": {
@@ -8743,6 +8774,20 @@
                                     },
                                     "isArchived": {
                                         "type": "boolean"
+                                    },
+                                    "managers": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "userId": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "userId"
+                                            ]
+                                        }
                                     }
                                 }
                             }
@@ -8815,8 +8860,8 @@
                 "operationId": "updatePerson"
             },
             "delete": {
-                "summary": "Delete a person",
-                "description": "Delete a person by their ID; fails when person has existing assignments or actuals to preserve\n          historical reports. Override this behaviour by using the force query flag.",
+                "summary": "Delete a person or placeholder",
+                "description": "Delete a person or placeholder by their ID; fails when person has existing assignments or actuals to preserve\n          historical reports. Override this behaviour by using the force query flag.",
                 "parameters": [
                     {
                         "schema": {
@@ -8981,8 +9026,7 @@
                         },
                         "in": "query",
                         "name": "modifiedAfter",
-                        "required": false,
-                        "description": "If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A person is considered \"modified\" if any of its core properties change. Actions that count as modifying a person include changing first name, last name, email, references, tags and archiving. A person is not considered modified just because another object it is associated with is changed (e.g. a contract, project or an assignment)."
+                        "required": false
                     },
                     {
                         "schema": {
@@ -9069,6 +9113,7 @@
                 "summary": "Create a person",
                 "description": "Also creates a new contract for the person",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -9084,6 +9129,10 @@
                                     },
                                     "email": {
                                         "type": "string"
+                                    },
+                                    "teamId": {
+                                        "type": "integer",
+                                        "nullable": true
                                     },
                                     "holidaysGroupId": {
                                         "type": "integer"
@@ -9106,6 +9155,20 @@
                                         "type": "array",
                                         "items": {
                                             "$ref": "#/components/schemas/Reference"
+                                        }
+                                    },
+                                    "managers": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "userId": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "userId"
+                                            ]
                                         }
                                     },
                                     "roleId": {
@@ -9179,8 +9242,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -9270,8 +9332,7 @@
                         },
                         "in": "query",
                         "name": "modifiedAfter",
-                        "required": false,
-                        "description": "If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ."
+                        "required": false
                     },
                     {
                         "schema": {
@@ -9759,7 +9820,7 @@
         },
         "/people/{personId}/assignments/": {
             "get": {
-                "summary": "List assignments for a person",
+                "summary": "List assignments for a person or placeholder",
                 "parameters": [
                     {
                         "schema": {
@@ -9995,6 +10056,7 @@
             "post": {
                 "summary": "Add a new contract to a person",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -10212,8 +10274,9 @@
         },
         "/people/{personId}/custom-fields/checkbox/": {
             "patch": {
-                "summary": "Add a checkbox custom value to a person",
+                "summary": "Add a checkbox custom value to a person or placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -10232,8 +10295,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -10315,8 +10377,9 @@
         },
         "/people/{personId}/custom-fields/date/": {
             "patch": {
-                "summary": "Add a date custom value to a person",
+                "summary": "Add a date custom value to a person or placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -10338,8 +10401,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -10424,8 +10486,9 @@
         },
         "/people/{personId}/custom-fields/select/": {
             "patch": {
-                "summary": "Add custom select options to a person",
+                "summary": "Add custom select options to a person or placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -10455,8 +10518,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -10549,8 +10611,9 @@
         },
         "/people/{personId}/custom-fields/text/": {
             "patch": {
-                "summary": "Add a text custom value to a person",
+                "summary": "Add a text custom value to a person or placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -10569,8 +10632,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -10652,7 +10714,7 @@
         },
         "/people/{personId}/projects/": {
             "get": {
-                "summary": "List projects for a person",
+                "summary": "List projects for a person or placeholder",
                 "parameters": [
                     {
                         "schema": {
@@ -10746,8 +10808,9 @@
                 "operationId": "listPersonProjects"
             },
             "post": {
-                "summary": "Add project to a person",
+                "summary": "Add project to a person or placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -10769,8 +10832,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -10833,7 +10895,7 @@
         },
         "/people/{personId}/skills/": {
             "get": {
-                "summary": "List skills for a person",
+                "summary": "List skills for a person or placeholder",
                 "parameters": [
                     {
                         "schema": {
@@ -10935,8 +10997,9 @@
                 "operationId": "listPersonSkills"
             },
             "post": {
-                "summary": "Add a skill to a person",
+                "summary": "Add a skill to a person or placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -10983,8 +11046,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -11044,8 +11106,9 @@
         },
         "/people/{personId}/skills/{skillId}": {
             "patch": {
-                "summary": "Update a skill for a person",
+                "summary": "Update a skill for a person or placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -11089,8 +11152,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -11156,7 +11218,7 @@
                 "operationId": "updatePersonSkill"
             },
             "delete": {
-                "summary": "Remove a skill from a person",
+                "summary": "Remove a skill from a person or placeholder",
                 "parameters": [
                     {
                         "schema": {
@@ -11216,7 +11278,8 @@
         },
         "/people/{personId}/teams/current": {
             "get": {
-                "summary": "Show current team",
+                "summary": "Show current team for a person or placeholder",
+                "description": "This endpoint is deprecated. You may view the current team for a person using the `GET /people/:personId/` endpoint.",
                 "parameters": [
                     {
                         "schema": {
@@ -11259,6 +11322,7 @@
                         "required": true
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "200": {
                         "description": "Default Response",
@@ -11327,8 +11391,10 @@
         },
         "/people/{personId}/teams/": {
             "post": {
-                "summary": "Add a person to a team",
+                "summary": "Add a person or placeholder to a team",
+                "description": "This endpoint is deprecated. You may assign the person to a team using the `PATCH /people/:personId/` endpoint.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -11343,8 +11409,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -11367,6 +11432,7 @@
                         "required": true
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "201": {
                         "description": "Default Response"
@@ -11387,7 +11453,8 @@
         },
         "/people/{personId}/teams/{teamId}": {
             "delete": {
-                "summary": "Remove a person from a team",
+                "summary": "Remove a person or placeholder from a team",
+                "description": "This endpoint is deprecated. You may remove the person from a team using the `PATCH /people/:personId/` endpoint.",
                 "parameters": [
                     {
                         "schema": {
@@ -11438,6 +11505,7 @@
                         "required": true
                     }
                 ],
+                "deprecated": true,
                 "responses": {
                     "202": {
                         "description": "Default Response"
@@ -11948,6 +12016,7 @@
             "post": {
                 "summary": "Create a people tag",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -11963,8 +12032,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -12131,6 +12199,7 @@
             "patch": {
                 "summary": "Update a people tag",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -12145,8 +12214,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -12472,6 +12540,7 @@
         "/placeholders/": {
             "get": {
                 "summary": "List placeholders",
+                "description": "Note: The /people/* endpoints also allows getting information on placeholders when using the `includePlaceholders` query parameter.",
                 "parameters": [
                     {
                         "schema": {
@@ -12607,6 +12676,7 @@
                 "summary": "Create a placeholder",
                 "description": "Also creates a contract that defaults to the role cost.\nPlease note that placeholders with no project or assignments will be deleted within 24 hours.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -12618,6 +12688,10 @@
                                     "costPerHour": {
                                         "description": "Defaults to the role's cost per hour",
                                         "type": "number"
+                                    },
+                                    "teamId": {
+                                        "type": "integer",
+                                        "nullable": true
                                     },
                                     "tags": {
                                         "type": "array",
@@ -12639,8 +12713,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -12704,6 +12777,7 @@
             "post": {
                 "summary": "Add a skill to a placeholder",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -12750,8 +12824,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -12883,6 +12956,7 @@
             "post": {
                 "summary": "Add a placeholder to a team",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -12897,8 +12971,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -13392,6 +13465,7 @@
             "patch": {
                 "summary": "Update a project tag",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -13406,8 +13480,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -13601,6 +13674,7 @@
             "post": {
                 "summary": "Create a project tag",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -13616,8 +13690,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -13984,6 +14057,7 @@
             "patch": {
                 "summary": "Update a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -14016,7 +14090,8 @@
                                         "type": "number"
                                     },
                                     "teamId": {
-                                        "type": "number"
+                                        "type": "number",
+                                        "nullable": true
                                     },
                                     "pricingModel": {
                                         "type": "string",
@@ -14202,8 +14277,7 @@
                         },
                         "in": "query",
                         "name": "modifiedAfter",
-                        "required": false,
-                        "description": "If provided, will only return objects modified after this timestamp. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ. Note: A project is considered \"modified\" if any of its core properties change. Actions that count as modifying a project include changing the name, client, status, pricing model, rate type , team, budget, expenses budget, references, and archiving. A project is not considered modified just because another object it is associated with is changed (e.g. actuals, assignments, budget roles, custom fields, milestones, notes, other expenses, people, people requests, phases, rates, timesheet locks & workstreams)."
+                        "required": false
                     },
                     {
                         "schema": {
@@ -14288,6 +14362,7 @@
             "post": {
                 "summary": "Create a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -14322,7 +14397,8 @@
                                                 "type": "number"
                                             },
                                             "teamId": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "nullable": true
                                             },
                                             "pricingModel": {
                                                 "type": "string",
@@ -14971,6 +15047,7 @@
                 "summary": "Update a project budget role",
                 "description": "Update a project budget role for a project. You cannot update a              project budget role using estimated budget if a project rate does              not exist for the role because the project rate is used to set              the estimatedMinutes.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -15256,6 +15333,7 @@
                 "summary": "Create a project budget role",
                 "description": "Create a project budget role for a project. You cannot create a              project budget role using estimated budget if a project rate does              not exist for the role because the project rate is used to set              the estimatedMinutes.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -15377,6 +15455,7 @@
             "patch": {
                 "summary": "Add a checkbox custom value to a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -15395,8 +15474,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -15480,6 +15558,7 @@
             "patch": {
                 "summary": "Add a date custom field value to a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -15501,8 +15580,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -15579,6 +15657,7 @@
             "patch": {
                 "summary": "Add a select custom field to a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -15608,8 +15687,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -15694,6 +15772,7 @@
             "patch": {
                 "summary": "Add a text custom field value to a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -15712,8 +15791,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -15787,6 +15865,7 @@
             "post": {
                 "summary": "Create a milestone for a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -15829,8 +15908,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -16084,6 +16162,7 @@
             "patch": {
                 "summary": "Update a milestone for a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -16202,6 +16281,7 @@
                 "summary": "Create a project note",
                 "description": "Defaults creator to 'API' user",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -16216,8 +16296,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -16498,6 +16577,7 @@
             "post": {
                 "summary": "Create an other expense for a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -16535,7 +16615,6 @@
                             }
                         }
                     },
-                    "required": true,
                     "description": "A non-labour expense for a project."
                 },
                 "parameters": [
@@ -16609,6 +16688,7 @@
             "patch": {
                 "summary": "Update an other expense on a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -16922,6 +17002,7 @@
                 "summary": "Create a person request on a project",
                 "description": "Person requests are used to request a placeholder role be filled with a person in the account or to request a new person be hired. This endpoint can be used to create a new person request.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -16945,8 +17026,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -17084,6 +17164,7 @@
                 "summary": "Update the status of a person request on a project",
                 "description": "Person requests are used to request a placeholder role be filled with another person in the account or to request a new person be hired. This endpoint can be used to update the status of a request to 'REQUESTED' or 'NEED_TO_HIRE', respectively.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -17103,8 +17184,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -17278,6 +17358,7 @@
             "post": {
                 "summary": "Create a phase for a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -17331,8 +17412,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -17442,6 +17522,7 @@
             "patch": {
                 "summary": "Update a phase for a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -17723,6 +17804,7 @@
             "patch": {
                 "summary": "Update a rate for a role on a project",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -17738,8 +17820,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -18212,6 +18293,7 @@
                 "summary": "Update a timesheet lock for a project",
                 "description": "This feature currently in beta and only available to selected customers.This will return an error and message if all timesheets haven't been filled out to selected date.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -18491,6 +18573,7 @@
             "post": {
                 "summary": "Create a rate card",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -18548,8 +18631,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -18717,6 +18799,125 @@
                     }
                 },
                 "operationId": "deleteRateCard"
+            },
+            "patch": {
+                "summary": "Update a rate card",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "references": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "referenceName": {
+                                                    "type": "string"
+                                                },
+                                                "externalId": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "referenceName",
+                                                "externalId"
+                                            ]
+                                        }
+                                    },
+                                    "isBlendedRateCard": {
+                                        "type": "boolean"
+                                    },
+                                    "blendedRate": {
+                                        "minimum": 0,
+                                        "type": "number",
+                                        "nullable": true
+                                    },
+                                    "rateType": {
+                                        "type": "string",
+                                        "enum": [
+                                            "hours",
+                                            "days"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "name": "rateCardId",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "default": "1.0.0",
+                            "enum": [
+                                "1.0.0"
+                            ]
+                        },
+                        "in": "header",
+                        "name": "accept-version",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RateCard"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BadRequest"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Unauthorized"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFound"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "updateRateCard"
             }
         },
         "/reports/hours/people/{personId}": {
@@ -18949,6 +19150,372 @@
                     }
                 },
                 "operationId": "getProjectHoursReport"
+            }
+        },
+        "/reports/people/{personId}/": {
+            "get": {
+                "summary": "Show metrics (beta)",
+                "description": "Get a report for a person containing data from the People Overview Report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.",
+                "parameters": [
+                    {
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "in": "query",
+                        "name": "startDate",
+                        "required": false,
+                        "description": "The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD"
+                    },
+                    {
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "monthly",
+                                "weekly",
+                                "quarterly"
+                            ],
+                            "default": "monthly"
+                        },
+                        "in": "query",
+                        "name": "periodType",
+                        "required": false,
+                        "description": "The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September."
+                    },
+                    {
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "name": "personId",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "default": "1.0.0",
+                            "enum": [
+                                "1.0.0"
+                            ]
+                        },
+                        "in": "header",
+                        "name": "accept-version",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer"
+                                        },
+                                        "firstName": {
+                                            "type": "string"
+                                        },
+                                        "lastName": {
+                                            "type": "string"
+                                        },
+                                        "email": {
+                                            "type": "string"
+                                        },
+                                        "jobTitle": {
+                                            "type": "string"
+                                        },
+                                        "team": {
+                                            "type": "string"
+                                        },
+                                        "employmentType": {
+                                            "type": "string"
+                                        },
+                                        "metrics": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "startDate": {
+                                                        "type": "string"
+                                                    },
+                                                    "endDate": {
+                                                        "type": "string"
+                                                    },
+                                                    "revenue": {
+                                                        "type": "number"
+                                                    },
+                                                    "projectCosts": {
+                                                        "type": "number"
+                                                    },
+                                                    "businessCosts": {
+                                                        "type": "number"
+                                                    },
+                                                    "totalEffortHours": {
+                                                        "type": "number"
+                                                    },
+                                                    "billableEffortHours": {
+                                                        "type": "number"
+                                                    },
+                                                    "nonBillableEffortHours": {
+                                                        "type": "number"
+                                                    },
+                                                    "totalUtilization": {
+                                                        "type": "number"
+                                                    },
+                                                    "billableUtilization": {
+                                                        "type": "number"
+                                                    },
+                                                    "contractCapacity": {
+                                                        "type": "number"
+                                                    },
+                                                    "effectiveCapacity": {
+                                                        "type": "number"
+                                                    },
+                                                    "overtime": {
+                                                        "type": "number"
+                                                    },
+                                                    "remainingAvailability": {
+                                                        "type": "number"
+                                                    },
+                                                    "timeOffHours": {
+                                                        "type": "number"
+                                                    },
+                                                    "completedTimesheet": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "startDate",
+                                                    "endDate",
+                                                    "revenue",
+                                                    "projectCosts",
+                                                    "businessCosts",
+                                                    "totalEffortHours",
+                                                    "billableEffortHours",
+                                                    "nonBillableEffortHours",
+                                                    "totalUtilization",
+                                                    "billableUtilization",
+                                                    "contractCapacity",
+                                                    "effectiveCapacity",
+                                                    "overtime",
+                                                    "remainingAvailability",
+                                                    "timeOffHours",
+                                                    "completedTimesheet"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "firstName",
+                                        "lastName",
+                                        "email",
+                                        "jobTitle",
+                                        "team",
+                                        "employmentType",
+                                        "metrics"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Unauthorized"
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "getPersonReport"
+            }
+        },
+        "/reports/projects/{projectId}/": {
+            "get": {
+                "summary": "Show metrics (beta)",
+                "description": "Get a report for a project containing data from the Project Overview report. Available under the Advanced Plan only. Contact help@runn.io to request beta access.",
+                "parameters": [
+                    {
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        },
+                        "in": "query",
+                        "name": "startDate",
+                        "required": false,
+                        "description": "The start date for the report. For monthly reports, this must be the first day of the month. For weekly reports, this must be a Monday. For quarterly reports, this must be the first day of the quarter. Format: YYYY-MM-DD"
+                    },
+                    {
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "monthly",
+                                "weekly",
+                                "quarterly"
+                            ]
+                        },
+                        "in": "query",
+                        "name": "periodType",
+                        "required": false,
+                        "description": "The time interval at which to split the metrics on the report. A monthly report made in June, for instance, will show revenue for June, July, August, and September. If not provided, the report will be for the Overview report (all inclusive)."
+                    },
+                    {
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "name": "projectId",
+                        "required": true
+                    },
+                    {
+                        "schema": {
+                            "default": "1.0.0",
+                            "enum": [
+                                "1.0.0"
+                            ]
+                        },
+                        "in": "header",
+                        "name": "accept-version",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer"
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "period": {
+                                            "type": "string"
+                                        },
+                                        "pricingModel": {
+                                            "type": "string",
+                                            "enum": [
+                                                "tm",
+                                                "fp",
+                                                "nb"
+                                            ]
+                                        },
+                                        "budget": {
+                                            "type": "number",
+                                            "nullable": true
+                                        },
+                                        "budgetRemaining": {
+                                            "type": "number"
+                                        },
+                                        "timeBudgetRemaining": {
+                                            "type": "number",
+                                            "nullable": true
+                                        },
+                                        "metrics": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "startDate": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
+                                                    "endDate": {
+                                                        "type": "string",
+                                                        "nullable": true
+                                                    },
+                                                    "timeMaterialsBenchmark": {
+                                                        "type": "number"
+                                                    },
+                                                    "revenue": {
+                                                        "type": "number"
+                                                    },
+                                                    "profit": {
+                                                        "type": "number"
+                                                    },
+                                                    "costs": {
+                                                        "type": "number"
+                                                    },
+                                                    "margin": {
+                                                        "description": "Percentage value of the profit margin",
+                                                        "type": "number"
+                                                    },
+                                                    "totalEffortHours": {
+                                                        "type": "number"
+                                                    },
+                                                    "billableEffortHours": {
+                                                        "type": "number"
+                                                    },
+                                                    "nonBillableEffortHours": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "startDate",
+                                                    "endDate",
+                                                    "timeMaterialsBenchmark",
+                                                    "revenue",
+                                                    "profit",
+                                                    "costs",
+                                                    "margin",
+                                                    "totalEffortHours",
+                                                    "billableEffortHours",
+                                                    "nonBillableEffortHours"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "id",
+                                        "name",
+                                        "pricingModel",
+                                        "budget",
+                                        "budgetRemaining",
+                                        "timeBudgetRemaining",
+                                        "metrics"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Unauthorized"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "message"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "operationId": "getProjectReport"
             }
         },
         "/reports/totals/projects/": {
@@ -19244,6 +19811,7 @@
             "post": {
                 "summary": "Create a role",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -19275,8 +19843,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -19387,6 +19954,7 @@
             "patch": {
                 "summary": "Update a role",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -19594,6 +20162,7 @@
             "post": {
                 "summary": "Create a skill",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -19609,8 +20178,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -19721,6 +20289,7 @@
             "patch": {
                 "summary": "Update a skill",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -19736,8 +20305,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -19985,6 +20553,7 @@
             "post": {
                 "summary": "Add people to a skill",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -20042,8 +20611,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -20249,6 +20817,7 @@
             "post": {
                 "summary": "Create a team",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -20264,8 +20833,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -20376,6 +20944,7 @@
             "patch": {
                 "summary": "Update a team",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -20391,8 +20960,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -20750,6 +21318,7 @@
             "post": {
                 "summary": "Create a holiday time off",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -21018,6 +21587,7 @@
                 "summary": "Create a leave time off",
                 "description": "\n#### Create or Update\n\nThis endpoint may return an existing time off if the new time off is a subset of an existing one.\n\n#### Automatic Merging\n\nIf one or more existing time offs overlap with the specified start/end date, they will be automatically merged.\n\n#### Partial Time Offs\n\nIf the `minutesPerDay` field is provided, automatic merging will only occur if any overlapping time off has the same `minutesPerDay` value. If the `minutesPerDay` value differs, the request will fail.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -21200,6 +21770,7 @@
                 "summary": "Create leave time offs in bulk",
                 "description": "\n#### Create or Update\n\nThis endpoint may return existing time offs if the new time off is a subset of an existing one.\n\n#### Automatic Merging\n\nIf one or more existing time offs overlap with the specified start/end date, they will be automatically merged.\n\n#### Partial Time Offs\n\nIf the `minutesPerDay` field is provided, automatic merging will only occur if any overlapping time off has the same `minutesPerDay` value. If the `minutesPerDay` value differs, the request will fail.",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -21219,8 +21790,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -21285,6 +21855,7 @@
             "delete": {
                 "summary": "Delete leave time offs in bulk",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -21304,8 +21875,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -22204,6 +22774,7 @@
             "post": {
                 "summary": "Create a workstream",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {
@@ -22219,8 +22790,7 @@
                                 ]
                             }
                         }
-                    },
-                    "required": true
+                    }
                 },
                 "parameters": [
                     {
@@ -22331,6 +22901,7 @@
             "patch": {
                 "summary": "Update a workstream",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "application/json": {
                             "schema": {


### PR DESCRIPTION
## Summary
- Synced OpenAPI spec from latest [Runn developer docs](https://developer.runn.io/reference/get_activity-log) (updated 2026-03-27)
- **New endpoints**: `GET /reports/people/{personId}/` (beta), `GET /reports/projects/{projectId}/` (beta), `PATCH /rate-cards/{rateCardId}`
- **New properties**: `managers` and `teamId` on person create/update, `teamId` (nullable) on project create/update and placeholder create
- **Deprecations**: `/people/{personId}/teams/` POST/GET/DELETE endpoints, `editOthersPermission`/`editProjectsPermission` fields
- **Fixes**: `requestBody.required: true` added to ~20 POST/PATCH endpoints, assignment list limit 500→200
- Preserved all 193 operationIds and prior linting improvements (0 errors, 1 warning vs 24 warnings before)
- Bumped version to v1.1.0

## Test plan
- [x] `just build` succeeds (SDK regenerated)
- [x] `speakeasy lint openapi --schema=runn.json` passes (0 errors, 1 warning)
- [ ] Verify release workflow triggers correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)